### PR TITLE
Support for supplying API Key as parameter

### DIFF
--- a/ITGlueAPI/Internal/APIKey.ps1
+++ b/ITGlueAPI/Internal/APIKey.ps1
@@ -1,17 +1,37 @@
-function Add-ITGlueAPIKey {
+function Add-ITGlueAPIKey
+{
+    [cmdletbinding()]
+    Param (
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [Alias('ApiKey')]
+        [string]$Api_Key
+    )
+    if ($Api_Key)
+    {
+        $x_api_key = ConvertTo-SecureString $Api_Key -AsPlainText -Force 
+
+        Set-Variable -Name "ITGlue_API_Key"  -Value $x_api_key -Option ReadOnly -Scope global -Force
+    }
+    else
+    {
         Write-Host "Please enter your API key:"
         $x_api_key = Read-Host -AsSecureString
 
         Set-Variable -Name "ITGlue_API_Key"  -Value $x_api_key -Option ReadOnly -Scope global -Force
+    }
 }
 
-
-function Remove-ITGlueAPIKey {
+function Remove-ITGlueAPIKey
+{
     Remove-Variable -Name "ITGlue_API_Key"  -Force  
 }
 
-function Get-ITGlueAPIKey {
+function Get-ITGlueAPIKey
+{
     $ITGlue_API_Key
+    
     Write-Host "Use Get-ITGlueAPIKey -Force to retrieve the unencrypted copy." -ForegroundColor "Red"
 }
 


### PR DESCRIPTION
Added support for supplying the API Key as a parameter alongside the existing Read-Host functionality