### PR TITLE
Charset specified to UTF-8

### DIFF
--- a/ITGlueAPI/ITGlueAPI.psm1
+++ b/ITGlueAPI/ITGlueAPI.psm1
@@ -1,5 +1,5 @@
 $ITGlue_Headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"   
-$ITGlue_Headers.Add("Content-Type", 'application/vnd.api+json') 
+$ITGlue_Headers.Add("Content-Type", 'application/vnd.api+json; charset=utf-8') 
 
 Set-Variable -Name "ITGlue_Headers"  -Value $ITGlue_Headers -Scope global
 


### PR DESCRIPTION
Invoke-RestMethod does not seem to have a charset specified and either PowerShell or ITGlue defaults to ISO-8859-1. (RFC). As a result, special characters does not work. Setting charset to UTF-8 in the header resolves the issue.