### PR TITLE
Corrected path check

### DIFF
--- a/ITGlueAPI/ITGlueAPI.psd1
+++ b/ITGlueAPI/ITGlueAPI.psd1
@@ -18,7 +18,7 @@ RootModule = '.\ITGlueAPI.psm1'
 # -- MINOR version when you add functionality in a backwards-compatible manner, and
 # -- PATCH version when you make backwards-compatible bug fixes.
 
-ModuleVersion = '2.0.4'
+ModuleVersion = '2.0.5'
 
 # ID used to uniquely identify this module
 #GUID = ''

--- a/ITGlueAPI/Resources/Configurations.ps1
+++ b/ITGlueAPI/Resources/Configurations.ps1
@@ -138,10 +138,6 @@ function Get-ITGlueConfigurations {
             $body += @{'page[size]' = $page_size}
         }
     }
-    else {
-        #Parameter set "Show" is selected; switch to nested relationships route
-        $resource_uri = ('/organizations/{0}/relationships/configurations/{1}' -f $organization_id, $id)
-    }
 
     if($include) {
         $body += @{'include' = $include}


### PR DESCRIPTION
Get-ITGlueConfigurations did not return data when only using parameter `-id`. See #58 for more information.