### PR TITLE
Null references and outputs updated

### DIFF
--- a/ITGlueAPI/Internal/APIKey.ps1
+++ b/ITGlueAPI/Internal/APIKey.ps1
@@ -24,7 +24,7 @@ function Remove-ITGlueAPIKey {
 }
 
 function Get-ITGlueAPIKey {
-    if($ITGlue_API_Key -eq $null) {
+    if($null -eq $ITGlue_API_Key) {
         Write-Error "No API key exists. Please run Add-ITGlueAPIKey to add one."
     }
     else {

--- a/ITGlueAPI/Resources/ConfigurationInterfaces.ps1
+++ b/ITGlueAPI/Resources/ConfigurationInterfaces.ps1
@@ -29,7 +29,7 @@ function New-ITGlueConfigurationInterfaces {
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -59,7 +59,7 @@ function Get-ITGlueConfigurationInterfaces {
     )
 
     $resource_uri = ('/configurations/{0}/relationships/configuration_interfaces/{1}' -f $conf_id, $id)
-    if (($PsCmdlet.ParameterSetName -eq 'show') -and ($conf_id -eq $null)) {
+    if (($PsCmdlet.ParameterSetName -eq 'show') -and ($null -eq $conf_id)) {
         $resource_uri = ('/configuration_interfaces/{0}' -f $id)
     }
 
@@ -91,7 +91,7 @@ function Get-ITGlueConfigurationInterfaces {
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 

--- a/ITGlueAPI/Resources/ConfigurationInterfaces.ps1
+++ b/ITGlueAPI/Resources/ConfigurationInterfaces.ps1
@@ -25,7 +25,7 @@ function New-ITGlueConfigurationInterfaces {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
@@ -87,7 +87,7 @@ function Get-ITGlueConfigurationInterfaces {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
@@ -138,7 +138,7 @@ function Set-ITGlueConfigurationInterfaces {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}

--- a/ITGlueAPI/Resources/ConfigurationStatuses.ps1
+++ b/ITGlueAPI/Resources/ConfigurationStatuses.ps1
@@ -15,10 +15,10 @@ function New-ITGlueConfigurationStatuses {
     $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
     $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
         -body $body -ErrorAction Stop -ErrorVariable $web_error
-    $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+    [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -53,7 +53,7 @@ function Get-ITGlueConfigurationStatuses {
         }
         if ($sort) {
             $body += @{'sort' = $sort}
-        }        
+        }
         if ($page_number) {
             $body += @{'page[number]' = $page_number}
         }
@@ -65,10 +65,10 @@ function Get-ITGlueConfigurationStatuses {
     $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
     $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
         -body $body -ErrorAction Stop -ErrorVariable $web_error
-    $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+    [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -81,7 +81,7 @@ function Set-ITGlueConfigurationStatuses {
         $data
     )
 
-    $resource_uri = ('/configuration_statuses/{0}' -f $id) 
+    $resource_uri = ('/configuration_statuses/{0}' -f $id)
 
     $body = @{}
 
@@ -92,9 +92,9 @@ function Set-ITGlueConfigurationStatuses {
     $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
     $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
         -body $body -ErrorAction Stop -ErrorVariable $web_error
-    $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+    [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/ConfigurationTypes.ps1
+++ b/ITGlueAPI/Resources/ConfigurationTypes.ps1
@@ -19,11 +19,11 @@ function New-ITGlueConfigurationTypes {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -74,11 +74,11 @@ function Get-ITGlueConfigurationTypes {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -91,7 +91,7 @@ function Set-ITGlueConfigurationTypes {
         $data
     )
 
-    $resource_uri = ('/configuration_types/{0}' -f $id) 
+    $resource_uri = ('/configuration_types/{0}' -f $id)
 
     $body = @{}
 
@@ -106,10 +106,10 @@ function Set-ITGlueConfigurationTypes {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/Configurations.ps1
+++ b/ITGlueAPI/Resources/Configurations.ps1
@@ -25,11 +25,11 @@ function New-ITGlueConfigurations {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -153,12 +153,12 @@ function Get-ITGlueConfigurations {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -257,11 +257,11 @@ function Set-ITGlueConfigurations {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -353,10 +353,10 @@ function Remove-ITGlueConfigurations {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/ContactTypes.ps1
+++ b/ITGlueAPI/Resources/ContactTypes.ps1
@@ -19,11 +19,11 @@ function New-ITGlueContactTypes {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -74,11 +74,11 @@ function Get-ITGlueContactTypes {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -91,7 +91,7 @@ function Set-ITGlueContactTypes {
         $data
     )
 
-    $resource_uri = ('/contact_types/{0}' -f $id) 
+    $resource_uri = ('/contact_types/{0}' -f $id)
 
     $body = @{}
 
@@ -106,10 +106,10 @@ function Set-ITGlueContactTypes {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/Contacts.ps1
+++ b/ITGlueAPI/Resources/Contacts.ps1
@@ -25,11 +25,11 @@ function New-ITGlueContacts {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -134,11 +134,11 @@ function Get-ITGlueContacts {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -225,11 +225,11 @@ function Set-ITGlueContacts {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -244,10 +244,10 @@ function Remove-ITGlueContacts {
 
         [Parameter(ParameterSetName = 'bulk_destroy')]
         [String]$filter_last_name = '',
-        
+
         [Parameter(ParameterSetName = 'bulk_destroy')]
         [String]$filter_title = '',
-        
+
         [Parameter(ParameterSetName = 'bulk_destroy')]
         [Nullable[Int64]]$filter_contact_type_id = $null,
 
@@ -308,10 +308,10 @@ function Remove-ITGlueContacts {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/Countries.ps1
+++ b/ITGlueAPI/Resources/Countries.ps1
@@ -23,7 +23,7 @@ function Get-ITGlueCountries {
     )
 
     $resource_uri = ('/countries/{0}' -f $id)
-    
+
     if ($PSCmdlet.ParameterSetName -eq "index") {
         if ($filter_name) {
             $body += @{'filter[name]' = $filter_name}
@@ -49,10 +49,10 @@ function Get-ITGlueCountries {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/FlexibleAssetFields.ps1
+++ b/ITGlueAPI/Resources/FlexibleAssetFields.ps1
@@ -29,7 +29,7 @@ function New-ITGlueFlexibleAssetFields {
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -57,7 +57,7 @@ function Get-ITGlueFlexibleAssetFields {
         [Parameter(ParameterSetName = 'show')]
         [Nullable[Int64]]$id = $null
     )
-    
+
     $resource_uri = ('/flexible_asset_fields/{0}' -f $id)
 
     if ($flexible_asset_type_id) {
@@ -80,7 +80,7 @@ function Get-ITGlueFlexibleAssetFields {
             $body += @{'page[size]' = $page_size}
         }
     }
-    elseif ($flexible_asset_type_id -eq $null) {
+    elseif ($null -eq $flexible_asset_type_id) {
         #Parameter set "Show" is selected and no flexible asset type id is specified; switch from nested relationships route
         $resource_uri = ('/flexible_asset_fields/{0}' -f $id)
     }
@@ -96,7 +96,7 @@ function Get-ITGlueFlexibleAssetFields {
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -147,7 +147,7 @@ function Set-ITGlueFlexibleAssetFields {
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -179,7 +179,7 @@ function Remove-ITGlueFlexibleAssetFields {
         }
 
         $data = @{}
-        $data = $rest_output 
+        $data = $rest_output
         return $data
     }
 }

--- a/ITGlueAPI/Resources/FlexibleAssetFields.ps1
+++ b/ITGlueAPI/Resources/FlexibleAssetFields.ps1
@@ -25,7 +25,7 @@ function New-ITGlueFlexibleAssetFields {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
@@ -92,7 +92,7 @@ function Get-ITGlueFlexibleAssetFields {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
@@ -143,7 +143,7 @@ function Set-ITGlueFlexibleAssetFields {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
@@ -175,7 +175,7 @@ function Remove-ITGlueFlexibleAssetFields {
         } catch {
             Write-Error $_
         } finally {
-            $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+            [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
         }
 
         $data = @{}

--- a/ITGlueAPI/Resources/FlexibleAssetTypes.ps1
+++ b/ITGlueAPI/Resources/FlexibleAssetTypes.ps1
@@ -19,11 +19,11 @@ function New-ITGlueFlexibleAssetTypes {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 function Get-ITGlueFlexibleAssetTypes {
@@ -96,11 +96,11 @@ function Get-ITGlueFlexibleAssetTypes {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -128,10 +128,10 @@ function Set-ITGlueFlexibleAssetTypes {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/FlexibleAssets.ps1
+++ b/ITGlueAPI/Resources/FlexibleAssets.ps1
@@ -19,11 +19,11 @@ function New-ITGlueFlexibleAssets {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -98,7 +98,7 @@ function Get-ITGlueFlexibleAssets {
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -129,11 +129,11 @@ function Set-ITGlueFlexibleAssets {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -155,11 +155,11 @@ function Remove-ITGlueFlexibleAssets {
         } catch {
             Write-Error $_
         } finally {
-            $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+            [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
         }
 
         $data = @{}
-        $data = $rest_output 
+        $data = $rest_output
         return $data
     }
 }

--- a/ITGlueAPI/Resources/Groups.ps1
+++ b/ITGlueAPI/Resources/Groups.ps1
@@ -43,10 +43,10 @@ function Get-ITGlueGroups {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/Locations.ps1
+++ b/ITGlueAPI/Resources/Locations.ps1
@@ -22,11 +22,11 @@ function New-ITGlueLocations {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 function Get-ITGlueLocations {
@@ -115,11 +115,11 @@ function Get-ITGlueLocations {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -190,11 +190,11 @@ function Set-ITGlueLocations {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -255,10 +255,10 @@ function Remove-ITGlueLocations {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/Manufacturers.ps1
+++ b/ITGlueAPI/Resources/Manufacturers.ps1
@@ -19,11 +19,11 @@ function New-ITGlueManufacturers {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -74,11 +74,11 @@ function Get-ITGlueManufacturers {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -106,10 +106,10 @@ function Set-ITGlueManufacturers {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/Models.ps1
+++ b/ITGlueAPI/Resources/Models.ps1
@@ -25,11 +25,11 @@ function New-ITGlueModels {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -87,11 +87,11 @@ function Get-ITGlueModels {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -138,10 +138,10 @@ function Set-ITGlueModels {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/OperatingSystems.ps1
+++ b/ITGlueAPI/Resources/OperatingSystems.ps1
@@ -45,10 +45,10 @@ function Get-ITGlueOperatingSystems {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/OrganizationStatuses.ps1
+++ b/ITGlueAPI/Resources/OrganizationStatuses.ps1
@@ -19,11 +19,11 @@ function New-ITGlueOrganizationStatuses {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -74,11 +74,11 @@ function Get-ITGlueOrganizationStatuses {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -106,10 +106,10 @@ function Set-ITGlueOrganizationStatuses {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/OrganizationTypes.ps1
+++ b/ITGlueAPI/Resources/OrganizationTypes.ps1
@@ -19,11 +19,11 @@ function New-ITGlueOrganizationTypes {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -75,11 +75,11 @@ function Get-ITGlueOrganizationTypes {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 function Set-ITGlueOrganizationTypes {
@@ -106,10 +106,10 @@ function Set-ITGlueOrganizationTypes {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/Organizations.ps1
+++ b/ITGlueAPI/Resources/Organizations.ps1
@@ -19,11 +19,11 @@ function New-ITGlueOrganizations {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -53,7 +53,7 @@ function Get-ITGlueOrganizations {
 
         [Parameter(ParameterSetName = 'index')]
         [Nullable[Int64]]$filter_exclude_id = $null,
-        
+
         [Parameter(ParameterSetName = 'index')]
         [String]$filter_exclude_name = '',
 
@@ -146,11 +146,11 @@ function Get-ITGlueOrganizations {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -162,7 +162,7 @@ function Set-ITGlueOrganizations {
 
         [Parameter(ParameterSetName = 'bulk_update')]
         [Nullable[Int64]]$filter_id = $null,
-        
+
         [Parameter(ParameterSetName = 'bulk_update')]
         [String]$filter_name = '',
 
@@ -251,11 +251,11 @@ function Set-ITGlueOrganizations {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -264,7 +264,7 @@ function Remove-ITGlueOrganizations {
     Param (
         [Parameter(ParameterSetName = 'bulk_destroy')]
         [Nullable[Int64]]$filter_id = $null,
-        
+
         [Parameter(ParameterSetName = 'bulk_destroy')]
         [String]$filter_name = '',
 
@@ -352,10 +352,10 @@ function Remove-ITGlueOrganizations {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/PasswordCategories.ps1
+++ b/ITGlueAPI/Resources/PasswordCategories.ps1
@@ -19,11 +19,11 @@ function New-ITGluePasswordCategories{
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -74,11 +74,11 @@ function Get-ITGluePasswordCategories {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -106,10 +106,10 @@ function Set-ITGluePasswordCategories {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/Passwords.ps1
+++ b/ITGlueAPI/Resources/Passwords.ps1
@@ -31,7 +31,7 @@ function New-ITGluePasswords {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
@@ -135,7 +135,7 @@ function Get-ITGluePasswords {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
@@ -184,7 +184,7 @@ function Set-ITGluePasswords {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
@@ -256,7 +256,7 @@ function Remove-ITGluePasswords {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}

--- a/ITGlueAPI/Resources/Passwords.ps1
+++ b/ITGlueAPI/Resources/Passwords.ps1
@@ -35,7 +35,7 @@ function New-ITGluePasswords {
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -85,7 +85,7 @@ function Get-ITGluePasswords {
         [Parameter(ParameterSetName = 'show')]
         $include = ''
     )
-    
+
     $resource_uri = ('/passwords/{0}' -f $id)
 
     if ($organization_id) {
@@ -115,7 +115,7 @@ function Get-ITGluePasswords {
         if ($page_size) {$body += @{'page[size]' = $page_size}
         }
     }
-    elseif ($organization_id -eq $null) {
+    elseif ($null -eq $organization_id) {
         #Parameter set "Show" is selected and no organization id is specified; switch from nested relationships route
         $resource_uri = ('/passwords/{0}' -f $id)
     }
@@ -139,7 +139,7 @@ function Get-ITGluePasswords {
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -188,7 +188,7 @@ function Set-ITGluePasswords {
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 

--- a/ITGlueAPI/Resources/Platforms.ps1
+++ b/ITGlueAPI/Resources/Platforms.ps1
@@ -43,10 +43,10 @@ function Get-ITGluePlatforms {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/Regions.ps1
+++ b/ITGlueAPI/Resources/Regions.ps1
@@ -62,10 +62,10 @@ function Get-ITGlueRegions {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/UserMetrics.ps1
+++ b/ITGlueAPI/Resources/UserMetrics.ps1
@@ -58,10 +58,10 @@ function Get-ITGlueUserMetrics {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }

--- a/ITGlueAPI/Resources/Users.ps1
+++ b/ITGlueAPI/Resources/Users.ps1
@@ -56,11 +56,11 @@ function Get-ITGlueUsers {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }
 
@@ -84,10 +84,10 @@ function Set-ITGlueUsers {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
-    $data = $rest_output 
+    $data = $rest_output
     return $data
 }


### PR DESCRIPTION
# Changed references null comparisons.
The way powershell handles $null in a comparison can allow for two $null values to become true.  fix is to place $null first in comparisons.
help about_Comparison_Operators

   When the input to an operator is a scalar value, comparison operators
   return a Boolean value. When the input is a collection of values, the
   comparison operators return any matching values. If there are no matches
   in a collection, comparison operators do not return anything.

   The exceptions are the containment operators (-Contains, -NotContains),
   the In operators (-In, -NotIn), and the type operators (-Is, -IsNot),
   which always return a Boolean value.
```powershell
<value_to_compare> -eq $null
$null -eq <value_to_compare>
```

# Changed the sending of output to null references to use [void] cast type.  This appears cleaner and is faster processing in the Powershell engine.
