### PR TITLE
Add support for creating, updating, and removing attachments

### DIFF
--- a/ITGlueAPI/ITGlueAPI.psd1
+++ b/ITGlueAPI/ITGlueAPI.psd1
@@ -72,6 +72,7 @@ PowerShellVersion = '3.0'
 NestedModules = 'Internal/BaseURI.ps1',
                 'Internal/APIKey.ps1',
                 'Internal/ModuleSettings.ps1',
+                'Resources/Attachments.ps1',
                 'Resources/ConfigurationInterfaces.ps1',
                 'Resources/Configurations.ps1',
                 'Resources/ConfigurationStatuses.ps1',
@@ -108,6 +109,10 @@ FunctionsToExport = 'Add-ITGlueAPIKey',
 
                     'Export-ITGlueModuleSettings',
                     'Import-ITGlueModuleSettings',
+
+                    'New-ITGlueAttachments',
+                    'Set-ITGlueAttachments',
+                    'Remove-ITGlueAttachments',
 
                     'New-ITGlueConfigurationInterfaces',
                     'Get-ITGlueConfigurationInterfaces',

--- a/ITGlueAPI/Resources/Attachments.ps1
+++ b/ITGlueAPI/Resources/Attachments.ps1
@@ -27,7 +27,7 @@ function New-ITGlueAttachments {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] $ITGlue_Headers.Remove('x-api-key') # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
@@ -69,7 +69,7 @@ function Set-ITGlueAttachments {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] $ITGlue_Headers.Remove('x-api-key') # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
@@ -107,7 +107,7 @@ function Remove-ITGlueAttachments {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] $ITGlue_Headers.Remove('x-api-key') # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}

--- a/ITGlueAPI/Resources/Attachments.ps1
+++ b/ITGlueAPI/Resources/Attachments.ps1
@@ -1,4 +1,5 @@
 function New-ITGlueAttachments {
+    [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $true)]    
         [ValidateSet( 'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents', `
@@ -36,7 +37,7 @@ function New-ITGlueAttachments {
 }
 
 function Set-ITGlueAttachments {
-    [CmdletBinding(DefaultParameterSetName = 'update')]
+    [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $true)]    
         [ValidateSet( 'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents', `
@@ -78,7 +79,7 @@ function Set-ITGlueAttachments {
 }
 
 function Remove-ITGlueAttachments {
-    [CmdletBinding(DefaultParameterSetName = 'bulk_destroy')]
+    [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $true)]    
         [ValidateSet( 'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents', `

--- a/ITGlueAPI/Resources/Attachments.ps1
+++ b/ITGlueAPI/Resources/Attachments.ps1
@@ -1,0 +1,116 @@
+function New-ITGlueAttachments {
+    Param (
+        [Parameter(Mandatory = $true)]    
+        [ValidateSet( 'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents', `
+                'domains', 'locations', 'passwords', 'ssl_certificates', 'flexible_assets', 'tickets')]
+        [string]$resource_type,
+
+        [Parameter(Mandatory = $true)]
+        [int64]$resource_id,
+
+        [Parameter(Mandatory = $true)]
+        $data
+    )
+
+    $resource_uri = ('/{0}/{1}/relationships/attachments' -f $resource_type, $resource_id)
+
+    $body = @{}
+
+    $body += @{'data'= $data}
+
+    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
+
+    try {
+        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
+        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
+            -body $body -ErrorAction Stop -ErrorVariable $web_error
+    } catch {
+        Write-Error $_
+    } finally {
+        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+    }
+
+    $data = @{}
+    $data = $rest_output 
+    return $data
+}
+
+function Set-ITGlueAttachments {
+    [CmdletBinding(DefaultParameterSetName = 'update')]
+    Param (
+        [Parameter(Mandatory = $true)]    
+        [ValidateSet( 'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents', `
+                'domains', 'locations', 'passwords', 'ssl_certificates', 'flexible_assets', 'tickets')]
+        [string]$resource_type,
+
+        [Parameter(Mandatory = $true)]
+        [int64]$resource_id,
+
+        [Parameter(Mandatory = $true)]
+        [int64]$attachment_id,
+
+        [Parameter(Mandatory = $true)]
+        $data
+
+    )
+
+    $resource_uri = ('/{0}/{1}/relationships/attachments/{2}' -f $resource_type, $resource_id, $attachment_id)
+
+    $body = @{}
+
+    $body += @{'data' = $data}
+
+    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
+
+    try {
+        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
+        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
+            -body $body -ErrorAction Stop -ErrorVariable $web_error
+    } catch {
+        Write-Error $_
+    } finally {
+        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+    }
+
+    $data = @{}
+    $data = $rest_output 
+    return $data
+}
+
+function Remove-ITGlueAttachments {
+    [CmdletBinding(DefaultParameterSetName = 'bulk_destroy')]
+    Param (
+        [Parameter(Mandatory = $true)]    
+        [ValidateSet( 'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents', `
+                'domains', 'locations', 'passwords', 'ssl_certificates', 'flexible_assets', 'tickets')]
+        [string]$resource_type,
+
+        [Parameter(Mandatory = $true)]
+        [int64]$resource_id,
+
+        [Parameter(Mandatory = $true)]
+        $data
+    )
+
+    $resource_uri = ('/{0}/{1}/relationships/attachments' -f $resource_type, $resource_id)
+
+    $body = @{}
+
+    $body += @{'data' = $data}
+
+    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
+
+    try {
+        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
+        $rest_output = Invoke-RestMethod -method 'DELETE' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
+            -body $body -ErrorAction Stop -ErrorVariable $web_error
+    } catch {
+        Write-Error $_
+    } finally {
+        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+    }
+
+    $data = @{}
+    $data = $rest_output 
+    return $data
+}


### PR DESCRIPTION
See #71

Very basic support.  All of the data hash table has to be manually created.

## Something like this

### upload new attachment
```
$filename = "C:\path\to\file\Blank.png"
$base64string = [Convert]::ToBase64String([IO.File]::ReadAllBytes($FileName))

$data = @{ 
    'type' = 'attachments'
    'attributes' = @{
        'attachment' = @{
            'content' = $base64string
            'file_name' = 'blank.png'
        }
    }
}

New-ITGlueAttachments -resource_type configurations -resource_id 22222222 -data $data
```

### rename attachment 1111111
```
$data = @{ 
    'type' = 'attachments'
    'attributes' = @{
        'name' = 'blank_renamed.png'
    }
}

Set-ITGlueAttachments -resource_type configurations -resource_id 22222222 -attachment_id 1111111-data $data
```


### remove attachment 1111111
```
$data = @{ 
    'type' = 'attachments'
    'attributes' = @{
        'id' = 1111111
    }
}

Remove-ITGlueAttachments -resource_type configurations -resource_id 22222222 -data $data
```