### PR TITLE
Add support for creating, updating, and removing related items

### DIFF
--- a/ITGlueAPI/ITGlueAPI.psd1
+++ b/ITGlueAPI/ITGlueAPI.psd1
@@ -94,6 +94,7 @@ NestedModules = 'Internal/BaseURI.ps1',
                 'Resources/Passwords.ps1',
                 'Resources/Platforms.ps1',
                 'Resources/Regions.ps1',
+                'Resources/RelatedItems.ps1',
                 'Resources/UserMetrics.ps1',
                 'Resources/Users.ps1'
 
@@ -193,6 +194,10 @@ FunctionsToExport = 'Add-ITGlueAPIKey',
                     'Get-ITGluePlatforms',
 
                     'Get-ITGlueRegions',
+
+                    'New-ITGlueRelatedItems',
+                    'Set-ITGlueRelatedItems',
+                    'Remove-ITGlueRelatedItems',
 
                     'Get-ITGlueUserMetrics',
 

--- a/ITGlueAPI/Resources/RelatedItems.ps1
+++ b/ITGlueAPI/Resources/RelatedItems.ps1
@@ -27,7 +27,7 @@ function New-ITGlueRelatedItems {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] $ITGlue_Headers.Remove('x-api-key') # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
@@ -69,7 +69,7 @@ function Set-ITGlueRelatedItems {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] $ITGlue_Headers.Remove('x-api-key') # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}
@@ -107,7 +107,7 @@ function Remove-ITGlueRelatedItems {
     } catch {
         Write-Error $_
     } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+        [void] $ITGlue_Headers.Remove('x-api-key') # Quietly clean up scope so the API key doesn't persist
     }
 
     $data = @{}

--- a/ITGlueAPI/Resources/RelatedItems.ps1
+++ b/ITGlueAPI/Resources/RelatedItems.ps1
@@ -1,0 +1,116 @@
+function New-ITGlueRelatedItems {
+    Param (
+        [Parameter(Mandatory = $true)]    
+        [ValidateSet( 'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents', `
+                'domains', 'locations', 'passwords', 'ssl_certificates', 'flexible_assets', 'tickets')]
+        [string]$resource_type,
+
+        [Parameter(Mandatory = $true)]
+        [int64]$resource_id,
+
+        [Parameter(Mandatory = $true)]
+        $data
+    )
+
+    $resource_uri = ('/{0}/{1}/relationships/related_items' -f $resource_type, $resource_id)
+
+    $body = @{}
+
+    $body += @{'data'= $data}
+
+    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
+
+    try {
+        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
+        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
+            -body $body -ErrorAction Stop -ErrorVariable $web_error
+    } catch {
+        Write-Error $_
+    } finally {
+        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+    }
+
+    $data = @{}
+    $data = $rest_output 
+    return $data
+}
+
+function Set-ITGlueRelatedItems {
+    [CmdletBinding(DefaultParameterSetName = 'update')]
+    Param (
+        [Parameter(Mandatory = $true)]    
+        [ValidateSet( 'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents', `
+                'domains', 'locations', 'passwords', 'ssl_certificates', 'flexible_assets', 'tickets')]
+        [string]$resource_type,
+
+        [Parameter(Mandatory = $true)]
+        [int64]$resource_id,
+
+        [Parameter(Mandatory = $true)]
+        [int64]$related_item_id,
+
+        [Parameter(Mandatory = $true)]
+        $data
+
+    )
+
+    $resource_uri = ('/{0}/{1}/relationships/related_items/{2}' -f $resource_type, $resource_id, $related_item_id)
+
+    $body = @{}
+
+    $body += @{'data' = $data}
+
+    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
+
+    try {
+        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
+        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
+            -body $body -ErrorAction Stop -ErrorVariable $web_error
+    } catch {
+        Write-Error $_
+    } finally {
+        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+    }
+
+    $data = @{}
+    $data = $rest_output 
+    return $data
+}
+
+function Remove-ITGlueRelatedItems {
+    [CmdletBinding(DefaultParameterSetName = 'bulk_destroy')]
+    Param (
+        [Parameter(Mandatory = $true)]    
+        [ValidateSet( 'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents', `
+                'domains', 'locations', 'passwords', 'ssl_certificates', 'flexible_assets', 'tickets')]
+        [string]$resource_type,
+
+        [Parameter(Mandatory = $true)]
+        [int64]$resource_id,
+
+        [Parameter(Mandatory = $true)]
+        $data
+    )
+
+    $resource_uri = ('/{0}/{1}/relationships/related_items' -f $resource_type, $resource_id)
+
+    $body = @{}
+
+    $body += @{'data' = $data}
+
+    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
+
+    try {
+        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
+        $rest_output = Invoke-RestMethod -method 'DELETE' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
+            -body $body -ErrorAction Stop -ErrorVariable $web_error
+    } catch {
+        Write-Error $_
+    } finally {
+        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
+    }
+
+    $data = @{}
+    $data = $rest_output 
+    return $data
+}

--- a/ITGlueAPI/Resources/RelatedItems.ps1
+++ b/ITGlueAPI/Resources/RelatedItems.ps1
@@ -48,14 +48,14 @@ function Set-ITGlueRelatedItems {
         [int64]$resource_id,
 
         [Parameter(Mandatory = $true)]
-        [int64]$related_item_id,
+        [int64]$id,
 
         [Parameter(Mandatory = $true)]
         $data
 
     )
 
-    $resource_uri = ('/{0}/{1}/relationships/related_items/{2}' -f $resource_type, $resource_id, $related_item_id)
+    $resource_uri = ('/{0}/{1}/relationships/related_items/{2}' -f $resource_type, $resource_id, $id)
 
     $body = @{}
 

--- a/ITGlueAPI/Resources/RelatedItems.ps1
+++ b/ITGlueAPI/Resources/RelatedItems.ps1
@@ -1,4 +1,5 @@
 function New-ITGlueRelatedItems {
+    [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $true)]    
         [ValidateSet( 'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents', `
@@ -36,7 +37,7 @@ function New-ITGlueRelatedItems {
 }
 
 function Set-ITGlueRelatedItems {
-    [CmdletBinding(DefaultParameterSetName = 'update')]
+    [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $true)]    
         [ValidateSet( 'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents', `
@@ -78,7 +79,7 @@ function Set-ITGlueRelatedItems {
 }
 
 function Remove-ITGlueRelatedItems {
-    [CmdletBinding(DefaultParameterSetName = 'bulk_destroy')]
+    [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $true)]    
         [ValidateSet( 'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents', `


### PR DESCRIPTION
See #71

Very basic support.  All of the data hash table has to be manually created.

## Something like this

### create new related item
```
$data = @{ 
    'type' = 'related_items'
    'attributes' = @{
        'destination_id' = 22222222
        'destination_type' = 'Configuration'
        'notes' = 'another computer'
    }
}

New-ITGlueRelatedItems -resource_type configurations -resource_id 22222222 -data $data
```

### update notes for related item 1111111
```
$data = @{ 
    'type' = 'related_items'
    'attributes' = @{
        'notes' = 'updated notes'
    }
}

Set-ITGlueRelatedItems -resource_type configurations -resource_id 22222222 -related_item_id 1111111 -data $data
```


### remove related item 1111111
```
$data = @{ 
    'type' = 'related_items'
    'attributes' = @{
        'id' = 1111111
    }
}

Remove-ITGlueRelatedItems -resource_type configurations -resource_id 22222222 -data $data
```