### PR TITLE
Remove double-quotes from Get-ITGlueUserMetrics

### DIFF
--- a/ITGlueAPI/Resources/UserMetrics.ps1
+++ b/ITGlueAPI/Resources/UserMetrics.ps1
@@ -53,7 +53,7 @@ function Get-ITGlueUserMetrics {
 
     try {
         $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
+        $rest_output = Invoke-RestMethod -method GET -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
             -body $body -ErrorAction Stop -ErrorVariable $web_error
     } catch {
         Write-Error $_


### PR DESCRIPTION
This previously raised an error where User metrics were not retrieved due to message stating `Cannot send a content-body with this verb-type`.  This issue has been fixed after removing the double quotes from the script in the `-Method` type for Invoke-RestMethod.