### PR TITLE
Add filter archived

### DIFF
--- a/ITGlueAPI/Resources/Configurations.ps1
+++ b/ITGlueAPI/Resources/Configurations.ps1
@@ -43,6 +43,12 @@ function Get-ITGlueConfigurations {
         [Parameter(ParameterSetName = 'index_rmm')]
         [Parameter(ParameterSetName = 'index_psa')]
         [Parameter(ParameterSetName = 'index_rmm_psa')]
+        [Bool]$filter_archived = '',
+
+        [Parameter(ParameterSetName = 'index')]
+        [Parameter(ParameterSetName = 'index_rmm')]
+        [Parameter(ParameterSetName = 'index_psa')]
+        [Parameter(ParameterSetName = 'index_rmm_psa')]
         [Parameter(ParameterSetName = 'show')]
         [Nullable[Int64]]$organization_id = $null,
 
@@ -163,6 +169,9 @@ function Get-ITGlueConfigurations {
         }
         if ($filter_organization_id) {
             $body += @{'filter[organization_id]' = $filter_organization_id}
+        }
+        if ($filter_archived) {
+            $body += @{'filter[archived]' = $filter_archived}
         }
         if ($filter_configuration_type_id) {
             $body += @{'filter[configuration_type_id]' = $filter_configuration_type_id}

--- a/ITGlueAPI/Resources/Configurations.ps1
+++ b/ITGlueAPI/Resources/Configurations.ps1
@@ -43,7 +43,7 @@ function Get-ITGlueConfigurations {
         [Parameter(ParameterSetName = 'index_rmm')]
         [Parameter(ParameterSetName = 'index_psa')]
         [Parameter(ParameterSetName = 'index_rmm_psa')]
-        [Bool]$filter_archived = '',
+        [Nullable[bool]]$filter_archived = $null,
 
         [Parameter(ParameterSetName = 'index')]
         [Parameter(ParameterSetName = 'index_rmm')]

--- a/ITGlueAPI/Resources/Passwords.ps1
+++ b/ITGlueAPI/Resources/Passwords.ps1
@@ -53,6 +53,9 @@ function Get-ITGluePasswords {
         [String]$filter_name = '',
 
         [Parameter(ParameterSetName = 'index')]
+        [bool]$filter_archived = '',
+
+        [Parameter(ParameterSetName = 'index')]
         [Nullable[Int64]]$filter_organization_id = $null,
 
         [Parameter(ParameterSetName = 'index')]
@@ -98,6 +101,8 @@ function Get-ITGluePasswords {
         if ($filter_id) {$body += @{'filter[id]' = $filter_id}
         }
         if ($filter_name) {$body += @{'filter[name]' = $filter_name}
+        }
+        if ($filter_archived) {$body += @{'filter[archived]' = $filter_archived}
         }
         if ($filter_organization_id) {$body += @{'filter[organization_id]' = $filter_organization_id}
         }

--- a/ITGlueAPI/Resources/Passwords.ps1
+++ b/ITGlueAPI/Resources/Passwords.ps1
@@ -53,7 +53,7 @@ function Get-ITGluePasswords {
         [String]$filter_name = '',
 
         [Parameter(ParameterSetName = 'index')]
-        [bool]$filter_archived = '',
+        [Nullable[bool]]$filter_archived = $null,
 
         [Parameter(ParameterSetName = 'index')]
         [Nullable[Int64]]$filter_organization_id = $null,


### PR DESCRIPTION
added ability to filter by archived passwords and configurations.  currently the API appears to only support this feature for passwords and configurations, and not for documents or flexible assets, even though you can apparently archive those in the UI.