### PR TITLE
Broken import when running without a profile

### DIFF
--- a/ITGlueAPI/ITGlueAPI.psd1
+++ b/ITGlueAPI/ITGlueAPI.psd1
@@ -18,7 +18,7 @@
     # -- MINOR version when you add functionality in a backwards-compatible manner, and
     # -- PATCH version when you make backwards-compatible bug fixes.
 
-    ModuleVersion = '2.1.0'
+    ModuleVersion = '2.1.1'
 
     # ID used to uniquely identify this module
     GUID = 'f969cff1-3120-4980-8c46-83f2d0bf2521'

--- a/ITGlueAPI/Internal/ModuleSettings.ps1
+++ b/ITGlueAPI/Internal/ModuleSettings.ps1
@@ -30,7 +30,7 @@ function Import-ITGlueModuleSettings {
         # Send to function to strip potentially superflous slash (/)
         Add-ITGlueBaseURI $tmp_config.ITGlue_Base_URI
 
-        $tmp_config.ITGlue_API_key = ConvertTo-SecureString $tmp_config.ITGlue_API_key
+        $tmp_config.ITGlue_API_key = ConvertTo-SecureString $tmp_config.ITGlue_API_key -ErrorAction SilentlyContinue
 
         Set-Variable -Name "ITGlue_API_Key"  -Value $tmp_config.ITGlue_API_key `
                     -Option ReadOnly -Scope global -Force


### PR DESCRIPTION
Most RMM systems run as the system account and thus have no profile to import. Added `-ErrorAction SilentlyContinue` to ignore the fact that there is no API key to convert into a secure string.