### PR TITLE
Remove HelpInfoURI from manifest

### DIFF
--- a/ITGlueAPI/ITGlueAPI.psd1
+++ b/ITGlueAPI/ITGlueAPI.psd1
@@ -269,7 +269,7 @@
     } # End of PrivateData hashtable
 
     # HelpInfo URI of this module
-    HelpInfoURI = 'https://github.com/itglue/powershellwrapper/wiki'
+    # HelpInfoURI = ''
 
     # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
     # DefaultCommandPrefix = ''


### PR DESCRIPTION
HelpInfoURI is not a general-purpose documentation URL; it is used with XML-based updatable help files and the Update-Help cmdlet. Since this URL is not a valid HelpInfo file, running Update-Help on any system with this module installed causes an error.