### PR TITLE
Addition of comment based help

### DIFF
--- a/ITGlueAPI/ITGlueAPI.psd1
+++ b/ITGlueAPI/ITGlueAPI.psd1
@@ -108,6 +108,7 @@
     FunctionsToExport = 'Add-ITGlueAPIKey',
                         'Get-ITGlueAPIKey',
                         'Remove-ITGlueAPIKey',
+                        'Test-ITGlueAPIKey',
 
                         'Add-ITGlueBaseURI',
                         'Get-ITGlueBaseURI',
@@ -115,6 +116,7 @@
 
                         'Export-ITGlueModuleSettings',
                         'Import-ITGlueModuleSettings',
+                        'Remove-ITGlueModuleSettings',
 
                         'New-ITGlueAttachments',
                         'Set-ITGlueAttachments',

--- a/ITGlueAPI/Internal/APIKey.ps1
+++ b/ITGlueAPI/Internal/APIKey.ps1
@@ -1,4 +1,41 @@
 function Add-ITGlueAPIKey {
+<#
+    .SYNOPSIS
+        Sets your API key used to authenticate all API calls.
+
+    .DESCRIPTION
+        The Add-ITGlueAPIKey cmdlet sets your API key which is used to
+        authenticate all API calls made to ITGlue.
+
+        ITGlue API keys can be generated via the ITGlue web interface
+            Account > API Keys
+
+    .PARAMETER Api_Key
+        Defines the API key that was generated from ITGlue.
+
+    .EXAMPLE
+        Add-ITGlueAPIKey
+
+        Prompts to enter in the API key
+
+    .EXAMPLE
+        Add-ITGlueAPIKey -Api_key 'some_api_key'
+
+        Will use the string entered into the [ -Api_Key ] parameter.
+
+    .EXAMPLE
+        '12345' | Add-ITGlueAPIKey
+
+        Will use the string passed into it as its API key.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $false, ValueFromPipeline = $true)]
@@ -6,30 +43,185 @@ function Add-ITGlueAPIKey {
         [Alias('ApiKey')]
         [string]$Api_Key
     )
-    if ($Api_Key) {
-        $x_api_key = ConvertTo-SecureString $Api_Key -AsPlainText -Force
 
-        Set-Variable -Name "ITGlue_API_Key" -Value $x_api_key -Option ReadOnly -Scope global -Force
-    }
-    else {
-        Write-Host "Please enter your API key:"
-        $x_api_key = Read-Host -AsSecureString
+    process{
 
-        Set-Variable -Name "ITGlue_API_Key" -Value $x_api_key -Option ReadOnly -Scope global -Force
+        if ($Api_Key) {
+            $x_api_key = ConvertTo-SecureString $Api_Key -AsPlainText -Force
+
+            Set-Variable -Name "ITGlue_API_Key" -Value $x_api_key -Option ReadOnly -Scope global -Force
+        }
+        else {
+            Write-Output "Please enter your API key:"
+            $x_api_key = Read-Host -AsSecureString
+
+            Set-Variable -Name "ITGlue_API_Key" -Value $x_api_key -Option ReadOnly -Scope global -Force
+        }
+
     }
+
 }
 
-function Remove-ITGlueAPIKey {
-    Remove-Variable -Name "ITGlue_API_Key" -Scope global -Force
-}
+
 
 function Get-ITGlueAPIKey {
-    if($null -eq $ITGlue_API_Key) {
-        Write-Error "No API key exists. Please run Add-ITGlueAPIKey to add one."
-    }
-    else {
+<#
+    .SYNOPSIS
+        Gets the ITGlue API key
+
+    .DESCRIPTION
+        The Get-ITGlueAPIKey cmdlet gets the ITGlue API key from
+        the global variable and returns it as a SecureString.
+
+    .EXAMPLE
+        Get-ITGlueAPIKey
+
+        Gets the ITGlue API key global variable and returns it as a SecureString.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
+    Param ()
+
+    if ($ITGlue_API_Key) {
         $ITGlue_API_Key
     }
+    else{
+        Write-Warning "No API key exists. Please run Add-ITGlueAPIKey to add one."
+    }
+
 }
+
+
+
+function Remove-ITGlueAPIKey {
+<#
+    .SYNOPSIS
+        Removes the ITGlue API key
+
+    .DESCRIPTION
+        The Remove-ITGlueAPIKey cmdlet removes the ITGlue API key from
+        global variable.
+
+    .EXAMPLE
+        Remove-ITGlueAPIKey
+
+        Removes the ITGlue API key global variable.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding(SupportsShouldProcess)]
+    Param ()
+
+    if ($ITGlue_API_Key) {
+        Remove-Variable -Name "ITGlue_API_Key" -Scope global -Force -WhatIf:$WhatIfPreference
+    }
+    else{
+        Write-Verbose 'The ITGlue API key variable is not set. Nothing to remove'
+    }
+}
+
+
+
+function Test-ITGlueAPIKey {
+<#
+    .SYNOPSIS
+        Test the ITGlue API key
+
+    .DESCRIPTION
+        The Test-ITGlueAPIKey cmdlet tests the base URI & API key that are defined
+        in the Add-ITGlueBaseURI & Add-ITGlueAPIKey cmdlets.
+
+        Helpful when needing to validate general functionality or when using
+        RMM deployment tools
+
+        The ITGlue Regions endpoint is called in this test
+
+    .PARAMETER base_uri
+        Define the base URI for the ITGlue API connection
+        using ITGlue's URI or a custom URI.
+
+        By default the value used is the one defined by Add-ITGlueBaseURI function
+            'https://api.itglue.com'
+
+    .EXAMPLE
+        Test-ITGlueApiKey
+
+        Tests the base URI & API key that are defined in the
+        Add-ITGlueBaseURI & Add-ITGlueAPIKey cmdlets.
+
+    .EXAMPLE
+        Test-ITGlueApiKey -base_uri http://myapi.gateway.example.com
+
+        Tests the defined base URI & API key that was defined in
+        the Add-ITGlueAPIKey cmdlet.
+
+        The full base uri test path in this example is:
+            http://myapi.gateway.example.com/regions
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
+    Param (
+        [parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$base_uri = $ITGlue_Base_URI
+    )
+
+    $resource_uri = "/regions"
+
+    Write-Verbose "Testing API key against [ $($base_uri + $resource_uri) ]"
+
+    try {
+
+        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
+
+        $rest_output = Invoke-WebRequest -Method Get -Uri ($base_uri + $resource_uri) -Headers $ITGlue_Headers -ErrorAction Stop
+    }
+    catch {
+
+        [PSCustomObject]@{
+            Method = $_.Exception.Response.Method
+            StatusCode = $_.Exception.Response.StatusCode.value__
+            StatusDescription = $_.Exception.Response.StatusDescription
+            Message = $_.Exception.Message
+            URI = $($base_uri + $resource_uri)
+        }
+
+    } finally {
+        [void] ($ITGlue_Headers.Remove('x-api-key'))
+    }
+
+    if ($rest_output){
+        $data = @{}
+        $data = $rest_output
+
+        [PSCustomObject]@{
+            StatusCode = $data.StatusCode
+            StatusDescription = $data.StatusDescription
+            URI = $($base_uri + $resource_uri)
+        }
+    }
+}
+
+
 
 New-Alias -Name Set-ITGlueAPIKey -Value Add-ITGlueAPIKey

--- a/ITGlueAPI/Internal/BaseURI.ps1
+++ b/ITGlueAPI/Internal/BaseURI.ps1
@@ -1,4 +1,57 @@
 function Add-ITGlueBaseURI {
+<#
+    .SYNOPSIS
+        Sets the base URI for the ITGlue API connection.
+
+    .DESCRIPTION
+        The Add-ITGlueBaseURI cmdlet sets the base URI which is used
+        to construct the full URI for all API calls.
+
+    .PARAMETER base_uri
+        Sets the base URI for the ITGlue API connection. Helpful
+        if using a custom API gateway.
+
+        The default value is 'https://api.itglue.com'
+
+    .PARAMETER data_center
+        Defines the data center to use which in turn defines which
+        base API URL is used.
+
+        Allowed values:
+        'US', 'EU', 'AU'
+
+            'US' = 'https://api.itglue.com'
+            'EU' = 'https://api.eu.itglue.com'
+            'AU' = 'https://api.au.itglue.com'
+
+    .EXAMPLE
+        Add-ITGlueBaseURI
+
+        The base URI will use https://api.itglue.com
+
+    .EXAMPLE
+        Add-ITGlueBaseURI -base_uri 'https://my.gateway.com'
+
+        The base URI will use https://my.gateway.com
+
+    .EXAMPLE
+        'https://my.gateway.com' | Add-ITGlueBaseURI
+
+        The base URI will use https://my.gateway.com
+
+    .EXAMPLE
+        Add-ITGlueBaseURI -data_center EU
+
+        The base URI will use https://api.eu.itglue.com
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [cmdletbinding()]
     Param (
         [parameter(ValueFromPipeline)]
@@ -9,27 +62,98 @@ function Add-ITGlueBaseURI {
         [String]$data_center = ''
     )
 
-    # Trim superfluous forward slash from address (if applicable)
-    if($base_uri[$base_uri.Length-1] -eq "/") {
-        $base_uri = $base_uri.Substring(0,$base_uri.Length-1)
+    process{
+
+        # Trim superfluous forward slash from address (if applicable)
+        if($base_uri[$base_uri.Length-1] -eq "/") {
+            $base_uri = $base_uri.Substring(0,$base_uri.Length-1)
+        }
+
+        switch ($data_center) {
+            'US' {$base_uri = 'https://api.itglue.com'}
+            'EU' {$base_uri = 'https://api.eu.itglue.com'}
+            'AU' {$base_uri = 'https://api.au.itglue.com'}
+            Default {}
+        }
+
+        Set-Variable -Name "ITGlue_Base_URI" -Value $base_uri -Option ReadOnly -Scope global -Force
+
     }
 
-    switch ($data_center) {
-        'US' {$base_uri = 'https://api.itglue.com'}
-        'EU' {$base_uri = 'https://api.eu.itglue.com'}
-        'AU' {$base_uri = 'https://api.au.itglue.com'}
-        Default {}
-    }
-
-    Set-Variable -Name "ITGlue_Base_URI" -Value $base_uri -Option ReadOnly -Scope global -Force
 }
 
-function Remove-ITGlueBaseURI {
-    Remove-Variable -Name "ITGlue_Base_URI" -Scope global -Force
-}
+
 
 function Get-ITGlueBaseURI {
-    $ITGlue_Base_URI
+<#
+    .SYNOPSIS
+        Shows the ITGlue base URI
+
+    .DESCRIPTION
+        The Get-ITGlueBaseURI cmdlet shows the ITGlue base URI from
+        the global variable
+
+    .EXAMPLE
+        Get-ITGlueBaseURI
+
+        Shows the ITGlue base URI value defined in the global variable
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
+    Param ()
+
+    if ($ITGlue_Base_URI){
+        $ITGlue_Base_URI
+    }
+    else{
+        Write-Warning "The ITGlue base URI is not set. Run Add-ITGlueBaseURI to set the base URI."
+    }
+
 }
+
+
+
+function Remove-ITGlueBaseURI {
+<#
+    .SYNOPSIS
+        Removes the ITGlue base URI global variable.
+
+    .DESCRIPTION
+        The Remove-ITGlueBaseURI cmdlet removes the ITGlue base URI from
+        the global variable.
+
+    .EXAMPLE
+        Remove-ITGlueBaseURI
+
+        Removes the ITGlue base URI value from the global variable
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding(SupportsShouldProcess)]
+    Param ()
+
+    if ($ITGlue_Base_URI) {
+        Remove-Variable -Name "ITGlue_Base_URI" -Scope global -Force -WhatIf:$WhatIfPreference
+    }
+    else{
+        Write-Verbose "The ITGlue base URI variable is not set. Nothing to remove"
+    }
+
+}
+
+
 
 New-Alias -Name Set-ITGlueBaseURI -Value Add-ITGlueBaseURI

--- a/ITGlueAPI/Internal/ModuleSettings.ps1
+++ b/ITGlueAPI/Internal/ModuleSettings.ps1
@@ -1,56 +1,280 @@
-# Locations of settings path and file
-$ITGlueAPIConfPath = "$($env:USERPROFILE)\ITGlueAPI"
-$ITGlueAPIConfFile = "config.psd1"
-
 function Export-ITGlueModuleSettings {
+<#
+    .SYNOPSIS
+        Exports the ITGlue BaseURI, API, & JSON configuration information to file.
+
+    .DESCRIPTION
+        The Export-ITGlueModuleSettings cmdlet exports the ITGlue BaseURI, API, &
+        JSON configuration information to file.
+
+        Making use of PowerShell's System.Security.SecureString type, exporting module settings
+        encrypts your API key in a format that can only be unencrypted with the Windows account
+        that encrypted the API key.
+
+        This means that you cannot copy your configuration file to another computer or
+        use another user account and expect it to work.
+
+    .PARAMETER itglue_api_conf_path
+        Define the location to store the ITGlue configuration file.
+
+        By default the configuration file is stored in the following location:
+            $env:USERPROFILE\ITGlueAPI
+
+    .PARAMETER itglue_api_conf_file
+        Define the name of the ITGlue configuration file.
+
+        By default the configuration file is named:
+            config.psd1
+
+    .PARAMETER open_conf_path
+        Opens the config path location, helpful for testing
+        and validation.
+
+    .EXAMPLE
+        Export-ITGlueModuleSettings
+
+        Validates that the BaseURI, API, and JSON depth are set then exports their values
+        to the current user's ITGlue configuration file located at:
+            $env:USERPROFILE\ITGlueAPI\config.psd1
+
+    .EXAMPLE
+        Export-ITGlueModuleSettings -itglue_api_conf_path C:\ITGlueAPI -itglue_api_conf_file MyConfig.psd1 -open_conf_path
+
+        Validates that the BaseURI, API, and JSON depth are set then exports their values
+        to the current user's ITGlue configuration file located at:
+            C:\ITGlueAPI\MyConfig.psd1
+
+        If the configuration file is successfully created then its save location is opened up.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$itglue_api_conf_path = "$($env:USERPROFILE)\ITGlueAPI",
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$itglue_api_conf_file = 'config.psd1',
+
+        [Parameter(Mandatory = $false)]
+        [switch]$open_conf_path
+    )
+
     # Confirm variables exist and are not null before exporting
     if ($ITGlue_Base_URI -and $ITGlue_API_Key -and $ITGlue_JSON_Conversion_Depth) {
         $secureString = $ITGlue_API_KEY | ConvertFrom-SecureString
-        New-Item -ItemType Directory -Force -Path $ITGlueAPIConfPath | ForEach-Object{$_.Attributes = "hidden"}
+        New-Item -ItemType Directory -Force -Path $itglue_api_conf_path | ForEach-Object {$_.Attributes = "hidden"}
 @"
 @{
     ITGlue_Base_URI = '$ITGlue_Base_URI'
     ITGlue_API_Key = '$secureString'
     ITGlue_JSON_Conversion_Depth = '$ITGlue_JSON_Conversion_Depth'
 }
-"@ | Out-File -FilePath ($ITGlueAPIConfPath+"\"+$ITGlueAPIConfFile) -Force
+"@ | Out-File -FilePath ($itglue_api_conf_path+"\"+$itglue_api_conf_file) -Force
+
+        if ( Test-Path ($itglue_api_conf_path+"\"+$itglue_api_conf_file) -PathType Leaf ){
+            Write-Output "ITGlueAPI Module configuration saved to [ $itglue_api_conf_path\$itglue_api_conf_file ]"
+
+            if ($open_conf_path){
+                Invoke-Item -Path $itglue_api_conf_path
+            }
+
+        }
+        else{
+            Write-Error "Failed to export ITGlue Module settings to [ $itglue_api_conf_path\$itglue_api_conf_file ]"
+        }
+
     }
     else {
-        Write-Host "Failed export ITGlue Module settings to $ITGlueAPIConfPath\$ITGlueAPIConfFile"
+        Write-Error "Failed to export ITGlue Module settings due to missing core variables"
     }
+
 }
 
+
+
 function Import-ITGlueModuleSettings {
+<#
+    .SYNOPSIS
+        Imports the ITGlue BaseURI, API, & JSON configuration information to the current session.
 
-    # PLEASE ADD ERROR CHECKING SUCH AS TESTING FOR VALID VARIABLES?
+    .DESCRIPTION
+        The Import-ITGlueModuleSettings cmdlet imports the ITGlue BaseURI, API, & JSON configuration
+        information stored in the ITGlue configuration file to the users current session.
 
-    if(test-path ($ITGlueAPIConfPath+"\"+$ITGlueAPIConfFile) )  {
-        $tmp_config = Import-LocalizedData -BaseDirectory $ITGlueAPIConfPath -FileName $ITGlueAPIConfFile
+        By default the configuration file is stored in the following location:
+            $env:USERPROFILE\ITGlueAPI
 
-        # Send to function to strip potentially superfluous slash (/)
-        Add-ITGlueBaseURI $tmp_config.ITGlue_Base_URI
+    .PARAMETER itglue_api_conf_path
+        Define the location to store the ITGlue configuration file.
 
-        $tmp_config.ITGlue_API_key = ConvertTo-SecureString $tmp_config.ITGlue_API_key
+        By default the configuration file is stored in the following location:
+            $env:USERPROFILE\ITGlueAPI
 
-        Set-Variable -Name "ITGlue_API_Key"  -Value $tmp_config.ITGlue_API_key `
-                    -Option ReadOnly -Scope global -Force
+    .PARAMETER itglue_api_conf_file
+        Define the name of the ITGlue configuration file.
 
-        Set-Variable -Name "ITGlue_JSON_Conversion_Depth" -Value $tmp_config.ITGlue_JSON_Conversion_Depth `
-                    -Scope global -Force
+        By default the configuration file is named:
+            config.psd1
 
-        Write-Host "ITGlueAPI Module configuration loaded successfully from $ITGlueAPIConfPath\$ITGlueAPIConfFile!" -ForegroundColor Green
+    .EXAMPLE
+        Import-ITGlueModuleSettings
+
+        Validates that the configuration file created with the Export-ITGlueModuleSettings cmdlet exists
+        then imports the stored data into the current users session.
+
+        The default location of the ITGlue configuration file is:
+            $env:USERPROFILE\ITGlueAPI\config.psd1
+
+    .EXAMPLE
+        Import-ITGlueModuleSettings -itglue_api_conf_path C:\ITGlueAPI -itglue_api_conf_file MyConfig.psd1
+
+        Validates that the configuration file created with the Export-ITGlueModuleSettings cmdlet exists
+        then imports the stored data into the current users session.
+
+        The location of the ITGlue configuration file in this example is:
+            C:\ITGlueAPI\MyConfig.psd1
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$itglue_api_conf_path = "$($env:USERPROFILE)\ITGlueAPI",
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$itglue_api_conf_file = 'config.psd1'
+    )
+
+    if( Test-Path ($itglue_api_conf_path+"\"+$itglue_api_conf_file ) -PathType Leaf ) {
+        $tmp_config = Import-LocalizedData -BaseDirectory $itglue_api_conf_path -FileName $itglue_api_conf_file
+
+            # Send to function to strip potentially superfluous slash (/)
+            Add-ITGlueBaseURI $tmp_config.ITGlue_Base_URI
+
+            $tmp_config.ITGlue_API_key = ConvertTo-SecureString $tmp_config.ITGlue_API_key
+
+            Set-Variable -Name "ITGlue_API_Key"  -Value $tmp_config.ITGlue_API_key -Option ReadOnly -Scope global -Force
+
+            Set-Variable -Name "ITGlue_JSON_Conversion_Depth" -Value $tmp_config.ITGlue_JSON_Conversion_Depth -Scope global -Force
+
+        Write-Verbose "ITGlueAPI Module configuration loaded successfully from [ $itglue_api_conf_path\$itglue_api_conf_file ]"
 
         # Clean things up
         Remove-Variable "tmp_config"
     }
     else {
-        Write-Host "No configuration file was found at $ITGlueAPIConfPath\$ITGlueAPIConfFile." -ForegroundColor Red
+        Write-Verbose "No configuration file was found at [ $itglue_api_conf_path\$itglue_api_conf_file ] run Add-ITGlueBaseURI & Add-ITGlueAPIKey to get started."
 
         Set-Variable -Name "ITGlue_Base_URI" -Value "https://api.itglue.com" -Option ReadOnly -Scope global -Force
-
-        Write-Host "Using https://api.itglue.com as Base URI. Run Add-ITGlueBaseURI to modify."
-        Write-Host "Please run Add-ITGlueAPIKey to get started." -ForegroundColor Red
-
         Set-Variable -Name "ITGlue_JSON_Conversion_Depth" -Value 100 -Scope global -Force
+    }
+}
+
+
+
+function Remove-ITGlueModuleSettings {
+<#
+    .SYNOPSIS
+        Removes the stored ITGlue configuration folder.
+
+    .DESCRIPTION
+        The Remove-ITGlueModuleSettings cmdlet removes the ITGlue folder and its files.
+        This cmdlet also has the option to remove sensitive ITGlue variables as well.
+
+        By default configuration files are stored in the following location and will be removed:
+            $env:USERPROFILE\ITGlueAPI
+
+    .PARAMETER itglue_api_conf_path
+        Define the location of the ITGlue configuration folder.
+
+        By default the configuration folder is located at:
+            $env:USERPROFILE\ITGlueAPI
+
+    .PARAMETER AndVariables
+        Define if sensitive ITGlue variables should be removed as well.
+
+        By default the variables are not removed.
+
+    .EXAMPLE
+        Remove-ITGlueModuleSettings
+
+        Checks to see if the default configuration folder exists and removes it if it does.
+
+        The default location of the ITGlue configuration folder is:
+            $env:USERPROFILE\ITGlueAPI
+
+    .EXAMPLE
+        Remove-ITGlueModuleSettings -itglue_api_conf_path C:\ITGlueAPI -AndVariables
+
+        Checks to see if the defined configuration folder exists and removes it if it does.
+        If sensitive ITGlue variables exist then they are removed as well.
+
+        The location of the ITGlue configuration folder in this example is:
+            C:\ITGlueAPI
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [CmdletBinding(SupportsShouldProcess)]
+    Param (
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$itglue_api_conf_path = "$($env:USERPROFILE)\ITGlueAPI",
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [switch]$AndVariables
+    )
+
+    if(Test-Path $itglue_api_conf_path) {
+
+        Remove-Item -Path $itglue_api_conf_path -Recurse -Force -WhatIf:$WhatIfPreference
+
+        If ($AndVariables) {
+            if ($ITGlue_API_Key) {
+                Remove-Variable -Name 'ITGlue_API_Key' -Scope Global -Force -WhatIf:$WhatIfPreference
+            }
+            if ($ITGlue_Base_URI) {
+                Remove-Variable -Name 'ITGlue_Base_URI' -Scope Global -Force -WhatIf:$WhatIfPreference
+            }
+        }
+
+
+        if ($WhatIfPreference -eq $false){
+
+            if ( !(Test-Path $itglue_api_conf_path) ) {
+                Write-Output "The ITGlueAPI configuration folder has been removed successfully from [ $itglue_api_conf_path ]"
+            }
+            else {
+                Write-Error "The ITGlueAPI configuration folder could not be removed from [ $itglue_api_conf_path ]"
+            }
+
+        }
+
+    }
+    else {
+        Write-Warning "No configuration folder found at [ $itglue_api_conf_path ]"
     }
 }

--- a/ITGlueAPI/Resources/Attachments.ps1
+++ b/ITGlueAPI/Resources/Attachments.ps1
@@ -1,4 +1,51 @@
 function New-ITGlueAttachments {
+<#
+    .SYNOPSIS
+        Adds an attachment to one or more assets
+
+    .DESCRIPTION
+        The New-ITGlueAttachments cmdlet adds an attachment
+        to one or more assets
+
+        Attachments are uploaded by including media data on the asset the attachment
+        is associated with. Attachments can be encoded and passed in JSON format for
+        direct upload, in which case the file has to be strict encoded.
+
+        Note that the name of the attachment will be taken from the file_name attribute
+        placed in the JSON body.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER resource_type
+        The resource type of the parent resource
+
+        Allowed values:
+        'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents',
+        'domains', 'locations', 'passwords', 'ssl_certificates', 'flexible_assets', 'tickets'
+
+    .PARAMETER resource_id
+        The resource id of the parent resource.
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueAttachments -resource_type passwords -resource_id 8756309 -data $json_object
+
+        Creates an attachment to a password with the defined id using the structured JSON object
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#attachments-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $true)]
@@ -19,7 +66,57 @@ function New-ITGlueAttachments {
 
 }
 
+
+
 function Set-ITGlueAttachments {
+<#
+    .SYNOPSIS
+        Updates the details of an existing attachment
+
+    .DESCRIPTION
+        The Set-ITGlueAttachments cmdlet updates the details of
+        an existing attachment
+
+        Only the attachment name that is displayed on the asset view
+        screen can be changed.
+
+        The original file_name can't be changed.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER resource_type
+        The resource type of the parent resource
+
+        Allowed values:
+        'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents',
+        'domains', 'locations', 'passwords', 'ssl_certificates', 'flexible_assets', 'tickets'
+
+    .PARAMETER resource_id
+        The resource id of the parent resource.
+
+    .PARAMETER id
+        The resource id of the existing attachment
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueAttachments -resource_type passwords -resource_id 8756309 -id 8756309 -data $json_object
+
+        Updates an attachment to a password with the defined id using the structured JSON object
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#attachments-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $true)]
@@ -43,7 +140,50 @@ function Set-ITGlueAttachments {
     return Invoke-ITGlueRequest -Method PATCH -ResourceURI $resource_uri -Data $data
 }
 
+
+
 function Remove-ITGlueAttachments {
+<#
+    .SYNOPSIS
+        Deletes one or more specified attachments
+
+    .DESCRIPTION
+        The Remove-ITGlueAttachments cmdlet deletes one
+        or more specified attachments
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER resource_type
+        The resource type of the parent resource
+
+        Allowed values:
+        'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents',
+        'domains', 'locations', 'passwords', 'ssl_certificates', 'flexible_assets', 'tickets'
+
+    .PARAMETER resource_id
+        The resource id of the parent resource.
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Remove-ITGlueAttachments -resource_type passwords -resource_id 8756309 -data $json_object
+
+        Using the defined JSON object this deletes an attachment from a
+        password with the defined id
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#attachments-bulk-destroy
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $true)]

--- a/ITGlueAPI/Resources/ConfigurationInterfaces.ps1
+++ b/ITGlueAPI/Resources/ConfigurationInterfaces.ps1
@@ -1,4 +1,40 @@
 function New-ITGlueConfigurationInterfaces {
+<#
+    .SYNOPSIS
+        Creates one or more configuration interfaces for a particular configuration(s).
+
+    .DESCRIPTION
+        The New-ITGlueConfigurationInterfaces cmdlet creates one or more configuration
+        interfaces for a particular configuration(s).
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER conf_id
+        A valid configuration ID in your account.
+
+        Example: 8765309
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueConfigurationInterfaces -conf_id 8765309 -data $json_object
+
+        Creates a configuration interface for the defined configuration using the structured JSON object
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#configuration-interfaces-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Nullable[Int64]]$conf_id = $null,
 
@@ -15,8 +51,87 @@ function New-ITGlueConfigurationInterfaces {
     return Invoke-ITGlueRequest -Method POST -ResourceURI $resource_uri -Data $data
 }
 
+
+
 function Get-ITGlueConfigurationInterfaces {
-    [CmdletBinding(DefaultParametersetName = 'index')]
+<#
+    .SYNOPSIS
+        Retrieve a configuration(s) interface(s).
+
+    .DESCRIPTION
+        The Get-ITGlueConfigurationInterfaces cmdlet retrieves a
+        configuration(s) interface(s).
+
+        This function can call the following endpoints:
+            Index = /configurations/:conf_id/relationships/configuration_interfaces
+
+            Show =  /configuration_interfaces/:id
+                    /configurations/:id/relationships/configuration_interfaces/:id
+
+    .PARAMETER conf_id
+        A valid configuration ID in your account.
+
+        Example: 8765309
+
+    .PARAMETER filter_id
+        Configuration id to filter by
+
+        Example: 8765309
+
+    .PARAMETER filter_ip_address
+        IP address to filter by
+
+        Example: 192.168.1.100
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'created_at', 'updated_at', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        A valid configuration interface ID in your account.
+
+        Example: 12345
+
+    .EXAMPLE
+        Get-ITGlueConfigurationInterfaces -conf_id 8765309
+
+        Gets an index of all the defined configurations interfaces
+
+    .EXAMPLE
+        Get-ITGlueConfigurationInterfaces -conf_id 8765309 -id 12345
+
+        Gets an a defined interface from a defined configuration
+
+    .EXAMPLE
+        Get-ITGlueConfigurationInterfaces -conf_id 8765309 -id 12345
+
+        Gets a defined interface from a defined configuration
+
+    .EXAMPLE
+        Get-ITGlueConfigurationInterfaces -id 12345
+
+        Gets a defined interface
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#configuration-interfaces-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index', Mandatory = $true)]
         [Parameter(ParameterSetName = 'show')]
@@ -76,8 +191,71 @@ function Get-ITGlueConfigurationInterfaces {
     return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
 }
 
+
+
 function Set-ITGlueConfigurationInterfaces {
-    [CmdletBinding(DefaultParametersetName = 'update')]
+<#
+    .SYNOPSIS
+        Update one or more configuration interfaces.
+
+    .DESCRIPTION
+        The Set-ITGlueConfigurationInterfaces cmdlet updates one
+        or more configuration interfaces.
+
+        Any attributes you don't specify will remain unchanged.
+
+        This function can call the following endpoints:
+            Update =    /configuration_interfaces/:id
+                        /configurations/:conf_id/relationships/configuration_interfaces/:id
+
+            Bulk_Update =   /configuration_interfaces
+                            /configurations/:conf_id/relationships/configuration_interfaces/:id
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        A valid configuration interface ID in your account.
+
+        Example: 12345
+
+    .PARAMETER conf_id
+        A valid configuration ID in your account.
+
+        Example: 8765309
+
+    .PARAMETER filter_id
+        Configuration id to filter by
+
+        Example: 8765309
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueConfigurationInterfaces -id 12345 -data $json_object
+
+        Updates an interface for the defined configuration with the structured
+        JSON object.
+
+    .EXAMPLE
+        Set-ITGlueConfigurationInterfaces -filter_id 8765309 -data $json_object
+
+        Bulk updates interfaces associated to the defined configuration filter
+        with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#configuration-interfaces-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [CmdletBinding(DefaultParameterSetName = 'update')]
     Param (
         [Parameter(ParameterSetName = 'update')]
         [Nullable[Int64]]$id,

--- a/ITGlueAPI/Resources/ConfigurationStatuses.ps1
+++ b/ITGlueAPI/Resources/ConfigurationStatuses.ps1
@@ -1,4 +1,35 @@
 function New-ITGlueConfigurationStatuses {
+<#
+    .SYNOPSIS
+        Creates a configuration status.
+
+    .DESCRIPTION
+        The New-ITGlueConfigurationStatuses cmdlet creates a new configuration
+        status in your account.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueConfigurationStatuses -data $json_object
+
+        Creates a new configuration status with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#configuration-statuses-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         $data
@@ -9,7 +40,68 @@ function New-ITGlueConfigurationStatuses {
     return Invoke-ITGlueRequest -Method POST -ResourceURI $resource_uri -Data $data
 }
 
+
+
 function Get-ITGlueConfigurationStatuses {
+<#
+    .SYNOPSIS
+        List or show all configuration(s) statuses.
+
+    .DESCRIPTION
+        The Get-ITGlueConfigurationStatuses cmdlet lists all or shows a
+        defined configuration(s) status.
+
+        This function can call the following endpoints:
+            Index = /configuration_statuses
+
+            Show =  /configuration_statuses/:id
+
+    .PARAMETER filter_name
+        Filter by configuration status name
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'id', 'created_at', 'updated_at', `
+        '-name', '-id', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Get a configuration status by id
+
+    .EXAMPLE
+        Get-ITGlueConfigurationStatuses
+
+        Returns the first 50 results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueConfigurationStatuses -id 12345
+
+        Returns the configuration status with the defined id
+
+    .EXAMPLE
+        Get-ITGlueConfigurationStatuses -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for configuration status
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#configuration-statuses-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]
@@ -52,7 +144,45 @@ function Get-ITGlueConfigurationStatuses {
     return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
 }
 
+
+
 function Set-ITGlueConfigurationStatuses {
+<#
+    .SYNOPSIS
+        Updates a configuration status.
+
+    .DESCRIPTION
+        The Set-ITGlueConfigurationStatuses cmdlet updates a configuration
+        status in your account.
+
+        Returns 422 Bad Request error if trying to update an externally synced record.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        Get a configuration status by id
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueConfigurationStatuses -id 8756309 -data $json_object
+
+        Updates the defined configuration status with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#configuration-statuses-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         [Int64]$id,

--- a/ITGlueAPI/Resources/ConfigurationTypes.ps1
+++ b/ITGlueAPI/Resources/ConfigurationTypes.ps1
@@ -1,4 +1,34 @@
 function New-ITGlueConfigurationTypes {
+<#
+    .SYNOPSIS
+        Creates a configuration type.
+
+    .DESCRIPTION
+        The New-ITGlueConfigurationTypes cmdlet creates a new configuration type.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueConfigurationTypes -data $json_object
+
+        Creates a new configuration type with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#configuration-types-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         $data
@@ -9,7 +39,68 @@ function New-ITGlueConfigurationTypes {
     return Invoke-ITGlueRequest -Method POST -ResourceURI $resource_uri -Data $data
 }
 
+
+
 function Get-ITGlueConfigurationTypes {
+<#
+    .SYNOPSIS
+        List or show all configuration type(s).
+
+    .DESCRIPTION
+        The Get-ITGlueConfigurationTypes cmdlet lists all or a single
+        configuration type(s).
+
+        This function can call the following endpoints:
+            Index =  /configuration_types
+
+            Show =   /configuration_types/:id
+
+    .PARAMETER filter_name
+        Filter by configuration type name
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'id', 'created_at', 'updated_at', `
+        '-name', '-id', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Define the configuration type by id
+
+    .EXAMPLE
+        Get-ITGlueConfigurationTypes
+
+        Returns the first 50 results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueConfigurationTypes -id 12345
+
+        Returns the configuration type with the defined id
+
+    .EXAMPLE
+        Get-ITGlueConfigurationTypes -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for configuration types
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#configuration-types-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]
@@ -52,7 +143,46 @@ function Get-ITGlueConfigurationTypes {
     return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
 }
 
+
+
 function Set-ITGlueConfigurationTypes {
+<#
+    .SYNOPSIS
+        Updates a configuration type.
+
+    .DESCRIPTION
+        The Set-ITGlueConfigurationTypes cmdlet updates a configuration type
+        in your account.
+
+        Returns 422 Bad Request error if trying to update an externally synced record.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        Define the configuration type by id
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueConfigurationTypes -id 8756309 -data $json_object
+
+        Update the defined configuration type with the structured
+        JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#configuration-types-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         [Int64]$id,

--- a/ITGlueAPI/Resources/Configurations.ps1
+++ b/ITGlueAPI/Resources/Configurations.ps1
@@ -1,4 +1,39 @@
 function New-ITGlueConfigurations {
+<#
+    .SYNOPSIS
+        Creates one or more configurations
+
+    .DESCRIPTION
+        The New-ITGlueConfigurations cmdlet creates one or more
+        configurations under a defined organization.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER organization_id
+        A valid organization Id in your Account
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueConfigurations -organization_id 8756309 -data $json_object
+
+        Creates a configuration in the defined organization with the
+        with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#configurations-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Nullable[Int64]]$organization_id = $null,
 
@@ -15,7 +50,125 @@ function New-ITGlueConfigurations {
     return Invoke-ITGlueRequest -Method POST -ResourceURI $resource_uri -Data $data
 }
 
+
+
 function Get-ITGlueConfigurations {
+<#
+    .SYNOPSIS
+        List all configurations in an account or organization
+
+    .DESCRIPTION
+        The Get-ITGlueConfigurations cmdlet lists all configurations
+        in an account or organization
+
+        This function can call the following endpoints:
+            Index = /configurations
+                    /organizations/:organization_id/relationships/configurations
+
+            Show =  /configurations/:id
+                    /organizations/:organization_id/relationships/configurations/:id
+
+    .PARAMETER id
+        A valid configuration Id
+
+    .PARAMETER filter_archived
+        Filter for archived
+
+        Allowed values:
+        'true', 'false', '1', '0'
+
+    .PARAMETER organization_id
+        A valid organization Id in your account
+
+    .PARAMETER filter_id
+        Filter by configuration id
+
+    .PARAMETER filter_name
+        Filter by configuration name
+
+    .PARAMETER filter_organization_id
+        Filter by organization name
+
+    .PARAMETER filter_configuration_type_id
+        Filter by configuration type id
+
+    .PARAMETER filter_configuration_status_id
+        Filter by configuration status id
+
+    .PARAMETER filter_contact_id
+        Filter by contact id
+
+    .PARAMETER filter_serial_number
+        Filter by a configurations serial number
+
+    .PARAMETER filter_psa_id
+        Filter by a PSA id
+
+    .PARAMETER filter_psa_integration_type
+        Filter by a PSA integration type
+
+        Allowed values:
+        'manage', 'autotask', 'tigerpaw', 'kaseya-bms', 'pulseway-psa', 'vorex'
+
+    .PARAMETER filter_rmm_id
+        Filter by a RMM id
+
+    .PARAMETER filter_rmm_integration_type
+        Filter by a RMM integration type
+
+        Allowed values:
+        'addigy', 'aem', 'atera', 'auvik', 'managed-workplace', `
+        'continuum', 'jamf-pro', 'kaseya-vsa', 'automate', 'log-me-in',`
+        'msp-rmm', 'meraki', 'msp-n-central', 'ninja-rmm', 'panorama9', `
+        'pulseway-rmm', 'syncro', 'watchman-monitoring'
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'id', 'created_at', 'updated-at', `
+        '-name', '-id', '-created_at', '-updated-at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER include
+        Include specified assets
+
+        Allowed values:
+        'adapters_resources', 'configuration_interfaces', 'rmm_records', 'passwords',
+        'attachments, tickets', 'user_resource_accesses', 'group_resource_accesses'
+
+    .EXAMPLE
+        Get-ITGlueConfigurations
+
+        Returns the first 50 configurations from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueConfigurations -filter_organization_id 10000855
+
+        Returns the first 50 configurations from the defined organization
+
+    .EXAMPLE
+        Get-ITGlueConfigurations -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for configurations
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#configurations-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'show')]
@@ -197,7 +350,96 @@ function Get-ITGlueConfigurations {
     return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
 }
 
+
+
 function Set-ITGlueConfigurations {
+<#
+    .SYNOPSIS
+        Updates one or more configurations
+
+    .DESCRIPTION
+        The Set-ITGlueConfigurations cmdlet updates the details
+        of one or more existing configurations
+
+        Any attributes you don't specify will remain unchanged.
+
+        This function can call the following endpoints:
+            Update = /configurations/:id
+                    /organizations/:organization_id/relationships/configurations/:id
+
+            Bulk_Update =  /configurations
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        A valid configuration Id
+
+    .PARAMETER organization_id
+        A valid organization Id in your account
+
+    .PARAMETER filter_id
+        Filter by configuration id
+
+    .PARAMETER filter_name
+        Filter by configuration name
+
+    .PARAMETER filter_organization_id
+        Filter by organization name
+
+    .PARAMETER filter_configuration_type_id
+        Filter by configuration type id
+
+    .PARAMETER filter_configuration_status_id
+        Filter by configuration status id
+
+    .PARAMETER filter_contact_id
+        Filter by contact id
+
+    .PARAMETER filter_serial_number
+        Filter by a configurations serial number
+
+    .PARAMETER filter_psa_id
+        Filter by a PSA id
+
+    .PARAMETER filter_psa_integration_type
+        Filter by a PSA integration type
+
+        Allowed values:
+        'manage', 'autotask', 'tigerpaw', 'kaseya-bms', 'pulseway-psa', 'vorex'
+
+    .PARAMETER filter_rmm_id
+        Filter by a RMM id
+
+    .PARAMETER filter_rmm_integration_type
+        Filter by a RMM integration type
+
+        Allowed values:
+        'addigy', 'aem', 'atera', 'auvik', 'managed-workplace', `
+        'continuum', 'jamf-pro', 'kaseya-vsa', 'automate', 'log-me-in',`
+        'msp-rmm', 'meraki', 'msp-n-central', 'ninja-rmm', 'panorama9', `
+        'pulseway-rmm', 'syncro', 'watchman-monitoring'
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueConfigurations -id 12345 -organization_id 10000855 -data $json_object
+
+        Updates a defined configuration in the defined organization with
+        the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#configurations-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'update')]
     Param (
         [Parameter(ParameterSetName = 'update')]
@@ -247,7 +489,6 @@ function Set-ITGlueConfigurations {
         [Parameter(ParameterSetName = 'bulk_update_psa')]
         [Parameter(ParameterSetName = 'bulk_update_rmm_psa')]
         [String]$filter_serial_number = '',
-
 
         [Parameter(ParameterSetName = 'bulk_update_psa')]
         [Parameter(ParameterSetName = 'bulk_update_rmm_psa')]
@@ -333,7 +574,75 @@ function Set-ITGlueConfigurations {
     return Invoke-ITGlueRequest -Method PATCH -ResourceURI $resource_uri -Data $data -QueryParams $query_params
 }
 
+
+
 function Remove-ITGlueConfigurations {
+<#
+    .SYNOPSIS
+        Deletes one or more configurations
+
+    .DESCRIPTION
+        The Remove-ITGlueConfigurations cmdlet deletes one or
+        more specified configurations
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        A valid configuration Id
+
+    .PARAMETER filter_id
+        Filter by configuration id
+
+    .PARAMETER filter_name
+        Filter by configuration name
+
+    .PARAMETER filter_organization_id
+        Filter by organization name
+
+    .PARAMETER filter_configuration_type_id
+        Filter by configuration type id
+
+    .PARAMETER filter_configuration_status_id
+        Filter by configuration status id
+
+    .PARAMETER filter_contact_id
+        Filter by contact id
+
+    .PARAMETER filter_serial_number
+        Filter by a configurations serial number
+
+    .PARAMETER filter_rmm_id
+        Filter by a RMM id
+
+    .PARAMETER filter_rmm_integration_type
+        Filter by a RMM integration type
+
+        Allowed values:
+        'addigy', 'aem', 'atera', 'auvik', 'managed-workplace', `
+        'continuum', 'jamf-pro', 'kaseya-vsa', 'automate', 'log-me-in',`
+        'msp-rmm', 'meraki', 'msp-n-central', 'ninja-rmm', 'panorama9', `
+        'pulseway-rmm', 'syncro', 'watchman-monitoring'
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Remove-ITGlueConfigurations -id 12345 -data $json_object
+
+        Deletes a defined configuration with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#configurations-bulk-destroy
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'bulk_delete')]
     Param (
         [Parameter(ParameterSetName = 'delete', Mandatory = $true)]

--- a/ITGlueAPI/Resources/ContactTypes.ps1
+++ b/ITGlueAPI/Resources/ContactTypes.ps1
@@ -1,4 +1,35 @@
 function New-ITGlueContactTypes {
+<#
+    .SYNOPSIS
+        Create a new contact type.
+
+    .DESCRIPTION
+        The New-ITGlueContactTypes cmdlet creates a new contact type in
+        your account
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueContactTypes -data $json_object
+
+        Creates a new contact type with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#contact-types-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         $data
@@ -9,7 +40,68 @@ function New-ITGlueContactTypes {
     return Invoke-ITGlueRequest -Method POST -ResourceURI $resource_uri -Data $data
 }
 
+
+
 function Get-ITGlueContactTypes {
+<#
+    .SYNOPSIS
+        List or show all contact types.
+
+    .DESCRIPTION
+        The Get-ITGlueContactTypes cmdlet returns a list of contacts types
+        in your account
+
+        This function can call the following endpoints:
+            Index = /contact_types
+
+            Show =  /contact_types/:id
+
+    .PARAMETER filter_name
+        Filter by a contact type name
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'id', 'created_at', 'updated_at', `
+        '-name', '-id', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Define a contact type id
+
+    .EXAMPLE
+        Get-ITGlueContactTypes
+
+        Returns the first 50 contact types from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueContactTypes -id 8765309
+
+        Returns the details of the defined contact type.
+
+    .EXAMPLE
+        Get-ITGlueContactTypes -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for contacts types
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#contact-types-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]
@@ -52,7 +144,45 @@ function Get-ITGlueContactTypes {
     return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
 }
 
+
+
 function Set-ITGlueContactTypes {
+<#
+    .SYNOPSIS
+        Updates a contact type.
+
+    .DESCRIPTION
+        The Set-ITGlueContactTypes cmdlet updates a contact type
+        in your account.
+
+        Returns 422 Bad Request error if trying to update an externally synced record.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        Define the contact type id to update
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueContactTypes -id 8756309 -data $json_object
+
+        Update the defined contact type with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#contact-types-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         [Int64]$id,

--- a/ITGlueAPI/Resources/Contacts.ps1
+++ b/ITGlueAPI/Resources/Contacts.ps1
@@ -1,4 +1,41 @@
 function New-ITGlueContacts {
+<#
+    .SYNOPSIS
+        Creates one or more contacts
+
+    .DESCRIPTION
+        The New-ITGlueContacts cmdlet creates one or more contacts
+        under the organization specified
+
+        Can also be used create multiple new contacts in bulk.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER organization_id
+        The organization id to create the contact(s) in
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueContacts -organization_id 8756309 -data $json_object
+
+        Create a new contact in the defined organization with the structured
+        JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#contacts-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Nullable[Int64]]$organization_id = $null,
 
@@ -15,7 +52,108 @@ function New-ITGlueContacts {
     return Invoke-ITGlueRequest -Method POST -ResourceURI $resource_uri -Data $data
 }
 
+
+
 function Get-ITGlueContacts {
+<#
+    .SYNOPSIS
+        List or show all contacts
+
+    .DESCRIPTION
+        The Get-ITGlueContacts cmdlet lists all or a single contact(s)
+        from your account or a defined organization.
+
+        This function can call the following endpoints:
+            Index = /contacts
+                    /organizations/:organization_id/relationships/contacts
+
+            Show =   /contacts/:id
+                    /organizations/:organization_id/relationships/contacts/:id
+
+    .PARAMETER organization_id
+        A valid organization Id in your account
+
+    .PARAMETER filter_id
+        Filter by contact id
+
+    .PARAMETER filter_first_name
+        Filter by contact first name
+
+    .PARAMETER filter_last_name
+        Filter by contact last name
+
+    .PARAMETER filter_title
+        Filter by contact title
+
+    .PARAMETER filter_contact_type_id
+        Filter by contact type id
+
+    .PARAMETER filter_important
+        Filter by if contact is important
+
+    .PARAMETER filter_primary_email
+        Filter by contact primary email address
+
+    .PARAMETER filter_psa_id
+        Filter by a PSA id
+
+    .PARAMETER filter_psa_integration_type
+        Filter by a PSA integration type
+
+        Allowed values:
+        'manage', 'autotask', 'tigerpaw', 'kaseya-bms', 'pulseway-psa', 'vorex'
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'first_name', 'last_name', 'id', 'created_at', 'updated_at', `
+        '-first_name', '-last_name', '-id', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Define a contact id
+
+    .PARAMETER include
+        Include specified assets
+
+        Allowed values:
+        'adapters_resources', 'location', 'passwords', 'attachments', 'tickets', 'distinct_remote_contacts',
+        'resource_fields, 'user_resource_accesses', 'group_resource_accesses', 'recent_versions',
+        'related_items', 'authorized_users'
+
+    .EXAMPLE
+        Get-ITGlueContacts
+
+        Returns the first 50 contacts from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueContacts -organization_id 8765309
+
+        Returns the first 50 contacts from the defined organization
+
+    .EXAMPLE
+        Get-ITGlueContacts -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for contacts
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#contacts-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]
@@ -138,7 +276,76 @@ function Get-ITGlueContacts {
     return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
 }
 
+
+
 function Set-ITGlueContacts {
+<#
+    .SYNOPSIS
+        Updates one or more contacts
+
+    .DESCRIPTION
+        The Set-ITGlueContacts cmdlet updates the details of one
+        or more specified contacts
+
+        Returns 422 Bad Request error if trying to update an externally synced record.
+
+        Any attributes you don't specify will remain unchanged.
+
+        This function can call the following endpoints:
+            Update = /contacts/:id
+                    /organizations/:organization_id/relationships/contacts/:id
+
+            Bulk_Update =  /contacts
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        Define a contact id
+
+    .PARAMETER organization_id
+        A valid organization Id in your account
+
+    .PARAMETER filter_id
+        Filter by contact id
+
+    .PARAMETER filter_first_name
+        Filter by contact first name
+
+    .PARAMETER filter_last_name
+        Filter by contact last name
+
+    .PARAMETER filter_title
+        Filter by contact title
+
+    .PARAMETER filter_contact_type_id
+        Filter by contact type id
+
+    .PARAMETER filter_important
+        Filter by if contact is important
+
+    .PARAMETER filter_primary_email
+        Filter by contact primary email address
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueContacts -id 8756309 -data $json_object
+
+        Updates the defined contact with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#contacts-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'update')]
     Param (
         [Parameter(ParameterSetName = 'update')]
@@ -213,7 +420,60 @@ function Set-ITGlueContacts {
     return Invoke-ITGlueRequest -Method PATCH -ResourceURI $resource_uri -Data $data -QueryParams $query_params
 }
 
+
+
 function Remove-ITGlueContacts {
+<#
+    .SYNOPSIS
+        Deletes one or more contacts
+
+    .DESCRIPTION
+        The Remove-ITGlueContacts cmdlet deletes one or more specified contacts
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER filter_id
+        Filter by contact id
+
+    .PARAMETER filter_first_name
+        Filter by contact first name
+
+    .PARAMETER filter_last_name
+        Filter by contact last name
+
+    .PARAMETER filter_title
+        Filter by contact title
+
+    .PARAMETER filter_contact_type_id
+        Filter by contact type id
+
+    .PARAMETER filter_important
+        Filter by if contact is important
+
+    .PARAMETER filter_primary_email
+        Filter by contact primary email address
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Remove-ITGlueContacts -filter_contact_type_id 8756309 -data $json_object
+
+        Deletes contacts with the defined type id with the structured
+        JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#contacts-bulk-destroy
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'bulk_destroy')]
     Param (
         [Parameter(ParameterSetName = 'bulk_destroy')]

--- a/ITGlueAPI/Resources/Countries.ps1
+++ b/ITGlueAPI/Resources/Countries.ps1
@@ -1,4 +1,66 @@
 function Get-ITGlueCountries {
+<#
+    .SYNOPSIS
+        Returns a list of supported countries.
+
+    .DESCRIPTION
+        The Get-ITGlueCountries cmdlet returns a list of supported countries
+        as well or details of one of the supported countries.
+
+        This function can call the following endpoints:
+            Index = /countries
+
+            Show =  /countries/:id
+
+    .PARAMETER filter_name
+        Filter by country name
+
+    .PARAMETER filter_iso
+        Filter by country iso abbreviation
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'id', 'created_at', 'updated_at', `
+        '-name', '-id', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Get a country by id
+
+    .EXAMPLE
+        Get-ITGlueCountries
+
+        Returns the first 50 results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueCountries -id 12345
+
+        Returns the country details with the defined id
+
+    .EXAMPLE
+        Get-ITGlueCountries -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for countries
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#countries-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = "index")]
     Param (
         [Parameter(ParameterSetName = "index")]

--- a/ITGlueAPI/Resources/Documents.ps1
+++ b/ITGlueAPI/Resources/Documents.ps1
@@ -1,4 +1,47 @@
 function Set-ITGlueDocuments {
+<#
+    .SYNOPSIS
+        Updates one or more documents
+
+    .DESCRIPTION
+        The Set-ITGlueDocuments cmdlet updates one or more existing documents
+
+        Any attributes you don't specify will remain unchanged.
+
+        This function can call the following endpoints:
+            Update =    /documents/:id
+                        /organizations/:organization_id/relationships/documents/:id
+
+            Bulk_Update =  /documents
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER organization_id
+        A valid organization Id in your Account
+
+    .PARAMETER id
+        The document id to update
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueDocuments -id 8756309 -data $json_object
+
+        Updates the defined document with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#documents-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'update')]
     Param (
         [Parameter(ParameterSetName = 'update')]

--- a/ITGlueAPI/Resources/Domains.ps1
+++ b/ITGlueAPI/Resources/Domains.ps1
@@ -1,4 +1,70 @@
 function Get-ITGlueDomains {
+<#
+    .SYNOPSIS
+        List or show all domains
+
+    .DESCRIPTION
+        The Get-ITGlueDomains cmdlet list or show all domains in
+        your account or from a specified organization
+
+        This function can call the following endpoints:
+            Index = /domains
+                    /organizations/:org_id/relationships/domains
+
+    .PARAMETER organization_id
+        A valid organization Id in your Account
+
+    .PARAMETER filter_id
+        The domain id to filter for
+
+    .PARAMETER filter_organization_id
+        The organization id to filter for
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'created_at', 'updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER include
+        Include specified assets
+
+        Allowed values:
+        'passwords', 'attachments', 'user_resource_accesses', 'group_resource_accesses'
+
+    .EXAMPLE
+        Get-ITGlueDomains
+
+        Returns the first 50 results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueDomains -organization_id 12345
+
+        Returns the domains from the defined organization id
+
+    .EXAMPLE
+        Get-ITGlueDomains -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for domains
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#domains-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]

--- a/ITGlueAPI/Resources/Expirations.ps1
+++ b/ITGlueAPI/Resources/Expirations.ps1
@@ -1,4 +1,98 @@
 function Get-ITGlueExpirations {
+<#
+    .SYNOPSIS
+        List or show all expirations
+
+    .DESCRIPTION
+        The Get-ITGlueExpirations cmdlet returns a list of expirations
+        for all organizations or for a specified organization.
+
+        This function can call the following endpoints:
+            Index = /expirations
+                    /organizations/:organization_id/relationships/expirations
+
+            Show =  /expirations/:id
+                    /organizations/:organization_id/relationships/expirations/:id
+
+    .PARAMETER organization_id
+        A valid organization Id in your account
+
+    .PARAMETER filter_id
+        Filter by expiration id
+
+    .PARAMETER filter_resource_id
+        Filter by a resource id
+
+    .PARAMETER filter_resource_name
+        Filter by a resource name
+
+    .PARAMETER filter_resource_type_name
+        Filter by a resource type name
+
+    .PARAMETER filter_description
+        Filter expiration description
+
+    .PARAMETER filter_expiration_date
+        Filter expiration date
+
+    .PARAMETER filter_organization_id
+        Filter by organization name
+
+    .PARAMETER filter_range
+        Filter by expiration range
+
+        To filter on a specific range, supply two comma-separated values
+        Example:
+            “2, 10” is filtering for all that are greater than or equal to 2
+            and less than or equal to 10
+
+        Or, an asterisk ( * ) can filter on values either greater than or equal to
+            Example:
+                “2, *”, or less than or equal to (“*, 10”)
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'id', 'organization_id', 'expiration_date', 'created_at', 'updated_at', `
+        '-id', '-organization_id', '-expiration_date', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        A valid organization Id in your account
+
+    .EXAMPLE
+        Get-ITGlueExpirations
+
+        Returns the first 50 results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueExpirations -id 12345
+
+        Returns the expiration with the defined id
+
+    .EXAMPLE
+        Get-ITGlueExpirations -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for expirations
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#expirations-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]

--- a/ITGlueAPI/Resources/FlexibleAssetFields.ps1
+++ b/ITGlueAPI/Resources/FlexibleAssetFields.ps1
@@ -1,4 +1,39 @@
 function New-ITGlueFlexibleAssetFields {
+<#
+    .SYNOPSIS
+        Creates one or more flexible asset fields
+
+    .DESCRIPTION
+        The New-ITGlueFlexibleAssetFields cmdlet creates one or more
+        flexible asset field for a particular flexible asset type.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER flexible_asset_type_id
+        The flexible asset type id to create a new field in
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueFlexibleAssetFields -flexible_asset_type_id 8756309 -data $json_object
+
+        Creates a new flexible asset field for the defined id with the structured
+        JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#flexible-asset-fields-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Nullable[Int64]]$flexible_asset_type_id = $null,
 
@@ -15,7 +50,81 @@ function New-ITGlueFlexibleAssetFields {
     return Invoke-ITGlueRequest -Method POST -RequestURI $resource_uri -Data $data
 }
 
+
+
 function Get-ITGlueFlexibleAssetFields {
+<#
+    .SYNOPSIS
+        List or show all flexible assets fields
+
+    .DESCRIPTION
+        The Get-ITGlueFlexibleAssetFields cmdlet lists or shows all flexible asset fields
+        for a particular flexible asset type.
+
+        This function can call the following endpoints:
+            Index = /flexible_asset_types/:fat_id/relationships/flexible_asset_fields
+
+            Show =  /flexible_asset_fields/:id
+                    /flexible_asset_types/:id/relationships/flexible_asset_fields/:id
+
+    .PARAMETER flexible_asset_type_id
+        A valid Flexible asset Id in your Account
+
+    .PARAMETER filter_id
+        Filter by a flexible asset field id
+
+    .PARAMETER filter_name
+        Filter by a flexible asset field name
+
+    .PARAMETER filter_icon
+        Filter by a flexible asset field icon
+
+    .PARAMETER filter_enabled
+        Filter if a flexible asset is enabled
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'created_at', 'updated_at', `
+        '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        A valid Flexible asset type Id in your Account
+
+    .EXAMPLE
+        Get-ITGlueFlexibleAssetFields -flexible_asset_type_id 12345
+
+        Returns all the fields in a flexible asset with the defined id
+
+    .EXAMPLE
+        Get-ITGlueFlexibleAssetFields -id 12345
+
+        Returns single field in a flexible asset with the defined id
+
+    .EXAMPLE
+        Get-ITGlueFlexibleAssetFields -flexible_asset_type_id 12345 -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for flexible asset fields
+        from the defined id.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#flexible-asset-fields-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]
@@ -88,7 +197,56 @@ function Get-ITGlueFlexibleAssetFields {
     return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
 }
 
+
+
 function Set-ITGlueFlexibleAssetFields {
+<#
+    .SYNOPSIS
+        Updates one or more flexible asset fields
+
+    .DESCRIPTION
+        The Set-ITGlueFlexibleAssetFields cmdlet updates the details of one
+        or more existing flexible asset fields
+
+        Any attributes you don't specify will remain unchanged.
+
+        Can also be used to bulk update flexible asset fields
+
+        Returns 422 error if trying to change the kind attribute of fields that
+        are already in use.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER flexible_asset_type_id
+        A valid Flexible asset Id in your Account
+
+    .PARAMETER id
+        Id of a flexible asset field
+
+    .PARAMETER filter_id
+        Filter by a flexible asset field id
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueFlexibleAssetFields -id 8756309 -data $json_object
+
+        Updates a defined flexible asset field with the structured
+        JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#flexible-asset-fields-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'update')]
     Param (
         [Parameter(ParameterSetName = 'update')]
@@ -123,7 +281,45 @@ function Set-ITGlueFlexibleAssetFields {
     return Invoke-ITGlueRequest -Method PATCH -ResourceURI $resource_uri -Data $data -QueryParams $query_params
 }
 
+
+
 function Remove-ITGlueFlexibleAssetFields {
+<#
+    .SYNOPSIS
+        Delete a flexible asset field.
+
+    .DESCRIPTION
+        The Remove-ITGlueFlexibleAssetFields cmdlet deletes a flexible asset field.
+
+        Note that this action will cause data loss if the field is already in use.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+
+    .PARAMETER id
+        Id of a flexible asset field
+
+    .PARAMETER flexible_asset_type_id
+        A valid Flexible asset Id in your Account
+
+    .EXAMPLE
+        Remove-ITGlueFlexibleAssetFields -id 8756309
+
+        Deletes a defined flexible asset field and any data associated to that
+        field.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#flexible-asset-fields-destroy
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory = $true)]

--- a/ITGlueAPI/Resources/FlexibleAssetTypes.ps1
+++ b/ITGlueAPI/Resources/FlexibleAssetTypes.ps1
@@ -1,4 +1,35 @@
 function New-ITGlueFlexibleAssetTypes {
+<#
+    .SYNOPSIS
+        Creates one or more flexible asset types
+
+    .DESCRIPTION
+        The New-ITGlueFlexibleAssetTypes cmdlet creates one or
+        more flexible asset types
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueFlexibleAssetTypes -data $json_object
+
+        Creates a new flexible asset type with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#flexible-asset-types-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         $data
@@ -8,7 +39,81 @@ function New-ITGlueFlexibleAssetTypes {
 
     return Invoke-ITGlueRequest -Method POST -ResourceURI $resource_uri -Data $data
 }
+
+
+
 function Get-ITGlueFlexibleAssetTypes {
+<#
+    .SYNOPSIS
+        List or show all flexible asset types
+
+    .DESCRIPTION
+        The Get-ITGlueFlexibleAssetTypes cmdlet returns details on a flexible asset type
+        or a list of flexible asset types in your account.
+
+        This function can call the following endpoints:
+            Index = /flexible_asset_types
+
+            Show =  /flexible_asset_types/:id
+
+    .PARAMETER filter_name
+        Filter by a flexible asset name
+
+    .PARAMETER filter_icon
+        Filter by a flexible asset icon
+
+    .PARAMETER filter_enabled
+        Filter if a flexible asset is enabled
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'id', 'created_at', 'updated_at', `
+        '-name', '-id', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER include
+        Include specified assets
+
+        Allowed values:
+        'flexible_asset_fields'
+
+    .PARAMETER id
+        A valid flexible asset id in your account
+
+    .EXAMPLE
+        Get-ITGlueFlexibleAssetTypes
+
+        Returns the first 50 flexible asset results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueFlexibleAssetTypes -id 12345
+
+        Returns the defined flexible asset with the defined id
+
+    .EXAMPLE
+        Get-ITGlueFlexibleAssetTypes -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for flexible assets
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#flexible-asset-types-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]
@@ -74,7 +179,45 @@ function Get-ITGlueFlexibleAssetTypes {
     return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
 }
 
+
+
 function Set-ITGlueFlexibleAssetTypes {
+<#
+    .SYNOPSIS
+        Updates a flexible asset type
+
+    .DESCRIPTION
+        The Set-ITGlueFlexibleAssetTypes cmdlet updates the details of an
+        existing flexible asset type in your account.
+
+        Any attributes you don't specify will remain unchanged.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        A valid flexible asset id in your account
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueFlexibleAssetTypes -id 8765309 -data $json_object
+
+        Update a flexible asset type with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#flexible-asset-types-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         [Int64]$id,

--- a/ITGlueAPI/Resources/FlexibleAssets.ps1
+++ b/ITGlueAPI/Resources/FlexibleAssets.ps1
@@ -1,4 +1,41 @@
 function New-ITGlueFlexibleAssets {
+<#
+    .SYNOPSIS
+        Creates one or more flexible assets
+
+    .DESCRIPTION
+        The New-ITGlueFlexibleAssets cmdlet creates one or more
+        flexible assets
+
+        If there are any required fields in the flexible asset type,
+        they will need to be included in the request.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER organization_id
+        The organization id to create the flexible asset in
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueFlexibleAssets -organization_id 8756309 -data $json_object
+
+        Creates a new flexible asset in the defined organization with the structured
+        JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#flexible-assets-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'create')]
     Param (
         [Parameter(ParameterSetName = 'create', Mandatory = $true)]
@@ -18,7 +55,84 @@ function New-ITGlueFlexibleAssets {
     return Invoke-ITGlueRequest -Method POST -ResourceURI $resource_uri -Data $data
 }
 
+
+
 function Get-ITGlueFlexibleAssets {
+<#
+    .SYNOPSIS
+        List or show all flexible assets
+
+    .DESCRIPTION
+        The Get-ITGlueFlexibleAssets cmdlet returns a list of flexible assets or
+        the details of a single flexible assets based on the unique ID of the
+        flexible asset type.
+
+        This function can call the following endpoints:
+            Index = /flexible_assets
+
+            Show =  /flexible_assets/:id
+
+    .PARAMETER filter_flexible_asset_type_id
+        Filter by a flexible asset id
+
+        This is the flexible assets id number you see in the URL under an organizations
+
+    .PARAMETER filter_name
+        Filter by a flexible asset name
+
+    .PARAMETER filter_organization_id
+        Filter by a organization id
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'created_at', 'updated_at', `
+        '-name', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER include
+        Include specified assets
+
+        Allowed values (Index):
+        'adapters_resources', 'distinct_remote_assets', 'attachments', 'passwords',
+        'user_resource_accesses', 'group_resource_accesses'
+
+        Allowed values (Show):
+        'adapters_resources', 'distinct_remote_assets', 'attachments', 'passwords',
+        'user_resource_accesses', 'group_resource_accesses', 'recent_versions', 'related_items',
+        'authorized_users'
+
+    .PARAMETER id
+        Get a flexible asset id
+
+    .EXAMPLE
+        Get-ITGlueFlexibleAssets -filter_flexible_asset_type_id 8765309
+
+        Returns the first 50 results for the defined flexible asset.
+
+    .EXAMPLE
+        Get-ITGlueFlexibleAssets -filter_flexible_asset_type_id 8765309 -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for the defined
+        flexible asset.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#flexible-assets-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]
@@ -81,7 +195,44 @@ function Get-ITGlueFlexibleAssets {
     return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
 }
 
+
+
 function Set-ITGlueFlexibleAssets {
+<#
+    .SYNOPSIS
+        Updates one or more flexible assets
+
+    .DESCRIPTION
+        The Set-ITGlueFlexibleAssets cmdlet updates one or more flexible assets
+
+        Any traits you don't specify will be deleted.
+        Passing a null value will also delete a trait's value.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        The flexible asset id to update
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueFlexibleAssets -id 8756309 -data $json_object
+
+        Updates a defined flexible asset with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#flexible-assets-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'update')]
     Param (
         [Parameter(ParameterSetName = 'update')]
@@ -98,7 +249,36 @@ function Set-ITGlueFlexibleAssets {
     return Invoke-ITGlueRequest -Method PATCH -ResourceURI $resource_uri -Data $data
 }
 
+
+
 function Remove-ITGlueFlexibleAssets {
+<#
+    .SYNOPSIS
+        Deletes one or more a flexible assets
+
+    .DESCRIPTION
+        The Remove-ITGlueFlexibleAssets cmdlet destroys multiple or a single
+        flexible asset.
+
+    .PARAMETER id
+        The flexible asset id to update
+
+    .EXAMPLE
+        Remove-ITGlueFlexibleAssets -id 8756309
+
+        Deletes the defined flexible asset
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#flexible-assets-destroy
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory = $true)]
@@ -110,4 +290,5 @@ function Remove-ITGlueFlexibleAssets {
     if ($pscmdlet.ShouldProcess($id)) {
         return Invoke-ITGlueRequest -Method DELETE -ResourceURI $resource_uri
     }
+
 }

--- a/ITGlueAPI/Resources/Groups.ps1
+++ b/ITGlueAPI/Resources/Groups.ps1
@@ -1,4 +1,63 @@
 function Get-ITGlueGroups {
+<#
+    .SYNOPSIS
+        List or show all groups
+
+    .DESCRIPTION
+        The Get-ITGlueGroups cmdlet returns a list of groups or the
+        details of a single group in your account.
+
+        This function can call the following endpoints:
+            Index = /groups
+
+            Show =  /groups/:id
+
+    .PARAMETER filter_name
+        Filter by a group name
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'created_at', 'updated_at', `
+        '-name', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Get a group by id
+
+    .EXAMPLE
+        Get-ITGlueGroups
+
+        Returns the first 50 group results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueGroups -id 12345
+
+        Returns the group with the defined id
+
+    .EXAMPLE
+        Get-ITGlueGroups -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for groups
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#groups-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]

--- a/ITGlueAPI/Resources/Locations.ps1
+++ b/ITGlueAPI/Resources/Locations.ps1
@@ -1,4 +1,39 @@
 function New-ITGlueLocations {
+<#
+    .SYNOPSIS
+        Creates one or more locations
+
+    .DESCRIPTION
+        The New-ITGlueLocations cmdlet creates one or more
+        locations for specified organization.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER org_id
+        The valid organization id in your account
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueLocations -org_id 8756309 -data $json_object
+
+        Creates a new location under the defined organization with the structured
+        JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#locations-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         [Int64]$org_id,
@@ -11,7 +46,106 @@ function New-ITGlueLocations {
 
     return Invoke-ITGlueRequest -Method POST -ResourceURI $resource_uri -Data $data
 }
+
+
+
 function Get-ITGlueLocations {
+<#
+    .SYNOPSIS
+        List or show all location
+
+    .DESCRIPTION
+        The Get-ITGlueLocations cmdlet returns a list of locations for
+        all organizations or for a specified organization.
+
+        This function can call the following endpoints:
+            Index = /locations
+                    /organizations/:org_id/relationships/locations
+
+            Show =  /locations/:id
+                    /organizations/:id/relationships/locations/:id
+
+    .PARAMETER org_id
+        The valid organization id in your account
+
+    .PARAMETER filter_id
+        Filter by a location id
+
+    .PARAMETER filter_name
+        Filter by a location name
+
+    .PARAMETER filter_city
+        Filter by a location city
+
+    .PARAMETER filter_region_id
+        Filter by a location region id
+
+    .PARAMETER filter_country_id
+        Filter by a location country id
+
+    .PARAMETER filter_psa_integration_type
+        Filter by a psa integration type
+
+        Allowed values:
+        'manage', 'autotask', 'tigerpaw', 'kaseya-bms', 'pulseway-psa', 'vorex'
+
+    .PARAMETER filter_psa_id
+        Filter by a psa integration id
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'id', 'created_at', 'updated_at', `
+        '-name', '-id', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Get a location by id
+
+    .PARAMETER include
+        Include specified assets
+
+        Allowed values(Index):
+        'adapters_resources', 'attachments', 'passwords', 'user_resource_accesses',
+        'group_resource_accesses'
+
+        Allowed values(Show):
+        'adapters_resources', 'attachments', 'passwords', 'user_resource_accesses',
+        'group_resource_accesses', 'recent_versions', 'related_items', 'authorized_users'
+
+    .EXAMPLE
+        Get-ITGlueLocations
+
+        Returns the first 50 location results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueLocations -id 12345
+
+        Returns the location with the defined id
+
+    .EXAMPLE
+        Get-ITGlueLocations -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for locations
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#locations-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]
@@ -118,7 +252,62 @@ function Get-ITGlueLocations {
     return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
 }
 
+
+
 function Set-ITGlueLocations {
+<#
+    .SYNOPSIS
+        Updates one or more a locations
+
+    .DESCRIPTION
+        The Set-ITGlueLocations cmdlet updates the details of
+        an existing location or locations.
+
+        Any attributes you don't specify will remain unchanged.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        Get a location by id
+
+    .PARAMETER org_id
+        The valid organization id in your account
+
+    .PARAMETER filter_id
+        Filter by a location id
+
+    .PARAMETER filter_name
+        Filter by a location name
+
+    .PARAMETER filter_city
+        Filter by a location city
+
+    .PARAMETER filter_region_id
+        Filter by a location region id
+
+    .PARAMETER filter_country_id
+        Filter by a location country id
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueLocations -id 8765309 -data $json_object
+
+        Updates the defined location with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#locations-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'update')]
     Param (
         [Parameter(ParameterSetName = 'update')]
@@ -177,7 +366,54 @@ function Set-ITGlueLocations {
     return Invoke-ITGlueRequest -Method PATCH -ResourceURI $resource_uri -Data $data -QueryParams $query_params
 }
 
+
+
 function Remove-ITGlueLocations {
+<#
+    .SYNOPSIS
+        Deletes one or more locations
+
+    .DESCRIPTION
+        The Set-ITGlueLocations cmdlet deletes one or more
+        specified locations
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER filter_id
+        Filter by a location id
+
+    .PARAMETER filter_name
+        Filter by a location name
+
+    .PARAMETER filter_city
+        Filter by a location city
+
+    .PARAMETER filter_region_id
+        Filter by a location region id
+
+    .PARAMETER filter_country_id
+        Filter by a location country id
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueLocations -id 8765309 -data $json_object
+
+        Updates the defined location with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#locations-bulk-destroy
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'bulk_destroy')]
     Param (
         [Parameter(ParameterSetName = 'bulk_destroy')]

--- a/ITGlueAPI/Resources/Logs.ps1
+++ b/ITGlueAPI/Resources/Logs.ps1
@@ -14,18 +14,18 @@ function Get-ITGlueLogs {
         in the last page the start date in the filter for the next request.
 
     .PARAMETER sort
-        Sort the order of the returned data
+        Sort results by a defined value
 
         Allowed values:
         'created_at','-created_at'
 
     .PARAMETER page_number
-        The page number to return data from
+        Return results starting from the defined number
 
         This endpoint is limited to 5 pages of results.
 
     .PARAMETER page_size
-        The number of results to return with each page
+        Number of results to return per page
 
         By default ITGlues API returned the first 50 items.
 

--- a/ITGlueAPI/Resources/Manufacturers.ps1
+++ b/ITGlueAPI/Resources/Manufacturers.ps1
@@ -1,4 +1,34 @@
 function New-ITGlueManufacturers {
+<#
+    .SYNOPSIS
+        Create a new manufacturer
+
+    .DESCRIPTION
+        The New-ITGlueManufacturers cmdlet creates a new manufacturer.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueManufacturers -data $json_object
+
+        Creates a new manufacturers with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#manufacturers-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         $data
@@ -9,7 +39,68 @@ function New-ITGlueManufacturers {
     return Invoke-ITGlueRequest -Method POST -ResourceURI $resource_uri -Data $data
 }
 
+
+
 function Get-ITGlueManufacturers {
+<#
+    .SYNOPSIS
+        List or show all manufacturers
+
+    .DESCRIPTION
+        The Get-ITGlueManufacturers cmdlet returns a manufacturer name
+        or a list of manufacturers in your account.
+
+        This function can call the following endpoints:
+            Index = /manufacturers
+
+            Show =  /manufacturers/:id
+
+    .PARAMETER filter_name
+        Filter by a manufacturers name
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'id', 'created_at', 'updated_at', `
+        '-name', '-id', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Get a manufacturer by id
+
+    .EXAMPLE
+        Get-ITGlueManufacturers
+
+        Returns the first 50 manufacturer results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueManufacturers -id 12345
+
+        Returns the manufacturer with the defined id
+
+    .EXAMPLE
+        Get-ITGlueManufacturers -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for manufacturers
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#manufacturers-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]
@@ -52,7 +143,44 @@ function Get-ITGlueManufacturers {
     return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
 }
 
+
+
 function Set-ITGlueManufacturers {
+<#
+    .SYNOPSIS
+        Updates a manufacturer
+
+    .DESCRIPTION
+        The New-ITGlueManufacturers cmdlet updates a manufacturer.
+
+        Returns 422 Bad Request error if trying to update an externally synced record.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        The id of the manufacturer to update
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueManufacturers -id 8765309 -data $json_object
+
+        Updates the defined manufacturer with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#manufacturers-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         [Int64]$id,

--- a/ITGlueAPI/Resources/Models.ps1
+++ b/ITGlueAPI/Resources/Models.ps1
@@ -1,4 +1,44 @@
 function New-ITGlueModels {
+<#
+    .SYNOPSIS
+        Creates one or more models
+
+    .DESCRIPTION
+        The New-ITGlueModels cmdlet creates one or more models
+        in your account or for a particular manufacturer.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER manufacturer_id
+        The manufacturer id to create the model under
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueModels -data $json_object
+
+        Creates a new model with the structured JSON object.
+
+    .EXAMPLE
+        New-ITGlueModels -manufacturer_id 8756309 -data $json_object
+
+        Creates a new model associated to the defined model with the
+        structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#models-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Nullable[Int64]]$manufacturer_id = $null,
 
@@ -15,7 +55,71 @@ function New-ITGlueModels {
     return Invoke-ITGlueRequest -Method POST -ResourceURI $resource_uri -Data $data
 }
 
+
+
 function Get-ITGlueModels {
+<#
+    .SYNOPSIS
+        List or show all models
+
+    .DESCRIPTION
+        The Get-ITGlueModels cmdlet returns a list of model names for all
+        manufacturers or for a specified manufacturer.
+
+        This function can call the following endpoints:
+            Index = /models
+
+            Show =  /manufacturers/:id/relationships/models
+
+    .PARAMETER manufacturer_id
+        Get models under the defined manufacturer id
+
+    .PARAMETER filter_id
+        Filter models by id
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'id', 'name', 'manufacturer_id', 'created_at', 'updated_at', `
+        '-id', '-name', '-manufacturer_id', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Get a model by id
+
+    .EXAMPLE
+        Get-ITGlueModels
+
+        Returns the first 50 model results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueModels -id 12345
+
+        Returns the model with the defined id
+
+    .EXAMPLE
+        Get-ITGlueModels -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for models
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#models-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]
@@ -65,7 +169,50 @@ function Get-ITGlueModels {
     return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
 }
 
+
+
 function Set-ITGlueModels {
+<#
+    .SYNOPSIS
+        Updates one or more models
+
+    .DESCRIPTION
+        The Set-ITGlueModels cmdlet updates an existing model or
+        set of models in your account.
+
+        Returns 422 Bad Request error if trying to update an externally synced record.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        Update a model by id
+
+    .PARAMETER manufacturer_id
+        Update models under the defined manufacturer id
+
+    .PARAMETER filter_id
+        Filter models by id
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueModels -id 8756309 -data $json_object
+
+        Updates the defined model with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#models-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'update')]
     Param (
         [Parameter(ParameterSetName = 'update')]

--- a/ITGlueAPI/Resources/OperatingSystems.ps1
+++ b/ITGlueAPI/Resources/OperatingSystems.ps1
@@ -1,4 +1,63 @@
 function Get-ITGlueOperatingSystems {
+<#
+    .SYNOPSIS
+        List or show all operating systems.
+
+    .DESCRIPTION
+        The Get-ITGlueOperatingSystems cmdlet returns a list of supported operating systems
+        or the details of a defined operating system.
+
+        This function can call the following endpoints:
+            Index = /operating_systems
+
+            Show =  /operating_systems/:id
+
+    .PARAMETER filter_name
+        Filter by operating system name
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'id', 'created_at', 'updated_at', `
+        '-name', '-id', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Get an operating system by id
+
+    .EXAMPLE
+        Get-ITGlueOperatingSystems
+
+        Returns the first 50 operating system results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueOperatingSystems -id 12345
+
+        Returns the operating systems with the defined id
+
+    .EXAMPLE
+        Get-ITGlueOperatingSystems -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for operating systems
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#operating-systems-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]

--- a/ITGlueAPI/Resources/OrganizationStatuses.ps1
+++ b/ITGlueAPI/Resources/OrganizationStatuses.ps1
@@ -1,4 +1,35 @@
 function New-ITGlueOrganizationStatuses {
+<#
+    .SYNOPSIS
+        Create an organization status.
+
+    .DESCRIPTION
+        The New-ITGlueOrganizationStatuses cmdlet creates a new organization
+        status in your account
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueOrganizationStatuses -data $json_object
+
+        Creates a new organization status with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#organization-statuses-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         $data
@@ -9,7 +40,68 @@ function New-ITGlueOrganizationStatuses {
     return Invoke-ITGlueRequest -Method POST -ResourceURI $resource_uri -Data $data
 }
 
+
+
 function Get-ITGlueOrganizationStatuses {
+<#
+    .SYNOPSIS
+        List or show all organization statuses
+
+    .DESCRIPTION
+        The Get-ITGlueOrganizationStatuses cmdlet returns a list of organization
+        statuses or the details of a single organization status in your account.
+
+        This function can call the following endpoints:
+            Index = /organization_statuses
+
+            Show =  /organization_statuses/:id
+
+    .PARAMETER filter_name
+        Filter by organization status name
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'id', 'created_at', 'updated_at', `
+        '-name', '-id', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Get an organization status by id
+
+    .EXAMPLE
+        Get-ITGlueOrganizationStatuses
+
+        Returns the first 50 organization statuses results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueOrganizationStatuses -id 12345
+
+        Returns the organization statuses with the defined id
+
+    .EXAMPLE
+        Get-ITGlueOrganizationStatuses -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for organization statuses
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#organization-statuses-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]
@@ -52,7 +144,46 @@ function Get-ITGlueOrganizationStatuses {
     return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
 }
 
+
+
 function Set-ITGlueOrganizationStatuses {
+<#
+    .SYNOPSIS
+        Updates an organization status
+
+    .DESCRIPTION
+        The Set-ITGlueOrganizationStatuses cmdlet updates an organization status
+        in your account.
+
+        Returns 422 Bad Request error if trying to update an externally synced record.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        Update an organization status by id
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueOrganizationStatuses -id 8756309 -data $json_object
+
+        Using the defined body this creates an attachment to a password with the structured
+        JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#organization-statuses-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         [Int64]$id,

--- a/ITGlueAPI/Resources/OrganizationTypes.ps1
+++ b/ITGlueAPI/Resources/OrganizationTypes.ps1
@@ -1,4 +1,35 @@
 function New-ITGlueOrganizationTypes {
+<#
+    .SYNOPSIS
+        Creates an organization type
+
+    .DESCRIPTION
+        The New-ITGlueOrganizationTypes cmdlet creates a new organization type
+        in your account.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueOrganizationTypes -data $json_object
+
+        Creates a new organization type with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#organization-types-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         $data
@@ -9,7 +40,68 @@ function New-ITGlueOrganizationTypes {
     return Invoke-ITGlueRequest -Method POST -ResourceURI $resource_uri -Data $data
 }
 
+
+
 function Get-ITGlueOrganizationTypes {
+<#
+    .SYNOPSIS
+        List or show all organization types
+
+    .DESCRIPTION
+        The Get-ITGlueOrganizationTypes cmdlet returns a list of organization types
+        or the details of a single organization type in your account.
+
+        This function can call the following endpoints:
+            Index = /organization_types
+
+            Show =  /organization_types/:id
+
+    .PARAMETER filter_name
+        Filter by organization type name
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'id', 'created_at', 'updated_at', `
+        '-name', '-id', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Get a organization type by id
+
+    .EXAMPLE
+        Get-ITGlueOrganizationTypes
+
+        Returns the first 50 organization type results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueOrganizationTypes -id 12345
+
+        Returns the organization type with the defined id
+
+    .EXAMPLE
+        Get-ITGlueOrganizationTypes -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for organization types
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#organization-types-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]
@@ -53,6 +145,42 @@ function Get-ITGlueOrganizationTypes {
 }
 
 function Set-ITGlueOrganizationTypes {
+<#
+    .SYNOPSIS
+        Updates an organization type
+
+    .DESCRIPTION
+        The Set-ITGlueOrganizationTypes cmdlet updates an organization type
+        in your account.
+
+        Returns 422 Bad Request error if trying to update an externally synced record.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        Update an organization type by id
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueOrganizationTypes -id 8756309 -data $json_object
+
+        Update the defined organization type with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#organization-types-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         [Int64]$id,

--- a/ITGlueAPI/Resources/Organizations.ps1
+++ b/ITGlueAPI/Resources/Organizations.ps1
@@ -1,4 +1,34 @@
 function New-ITGlueOrganizations {
+<#
+    .SYNOPSIS
+        Create an organization.
+
+    .DESCRIPTION
+        The New-ITGlueOrganizations cmdlet creates an organization.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueOrganizations -data $json_object
+
+        Creates a new organization with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#organizations-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         $data
@@ -9,7 +39,111 @@ function New-ITGlueOrganizations {
     return Invoke-ITGlueRequest -Method POST -ResourceURI $resource_uri -Data $data
 }
 
+
+
 function Get-ITGlueOrganizations {
+<#
+    .SYNOPSIS
+        List or show all organizations
+
+    .DESCRIPTION
+        The Get-ITGlueOrganizations cmdlet returns a list of organizations
+        or details for a single organization in your account.
+
+        This function can call the following endpoints:
+            Index = /organizations
+
+            Show =  /organizations/:id
+
+    .PARAMETER filter_id
+        Filter by an organization id
+
+    .PARAMETER filter_name
+        Filter by an organization name
+
+    .PARAMETER filter_organization_type_id
+        Filter by an organization type id
+
+    .PARAMETER filter_organization_status_id
+        Filter by an organization status id
+
+    .PARAMETER filter_created_at
+        Filter by when an organization created
+
+    .PARAMETER filter_updated_at
+        Filter by when an organization updated
+
+    .PARAMETER filter_my_glue_account_id
+        Filter by a MyGlue id
+
+    .PARAMETER filter_group_id
+        Filter by a group id
+
+    .PARAMETER filter_exclude_id
+        Filter to excluded a certain organization id
+
+    .PARAMETER filter_exclude_name
+        Filter to excluded a certain organization name
+
+    .PARAMETER filter_exclude_organization_type_id
+        Filter to excluded a certain organization type id
+
+    .PARAMETER filter_exclude_organization_status_id
+        Filter to excluded a certain organization status id
+
+    .PARAMETER filter_range
+        Filter organizations by range?
+
+    .PARAMETER filter_range_my_glue_account_id
+        Filter MyGLue organization id range?
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'id', 'updated_at', 'organization_status_name', 'organization_type_name',
+        'created_at', 'short_name', 'my_glue_account_id', '-name', '-id', '-updated_at',
+        '-organization_status_name', '-organization_type_name', '-created_at',
+        '-short_name', '-my_glue_account_id'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Get an organization by id
+
+    .EXAMPLE
+        Get-ITGlueOrganizations
+
+        Returns the first 50 organizations results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueOrganizations -id 12345
+
+        Returns the organization with the defined id
+
+    .EXAMPLE
+        Get-ITGlueOrganizations -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for organizations
+        in your ITGlue account
+
+    .NOTES
+        As of 2022-12
+            Need to figure out the "filter_range***" parameters
+            Need to figure out the "filter_group_id" parameter
+
+    .LINK
+        https://api.itglue.com/developer/#organizations-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]
@@ -130,7 +264,85 @@ function Get-ITGlueOrganizations {
     return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
 }
 
+
+
 function Set-ITGlueOrganizations {
+<#
+    .SYNOPSIS
+        Updates one or more organizations
+
+    .DESCRIPTION
+        The Set-ITGlueOrganizations cmdlet updates the details of an
+        existing organization or multiple organizations.
+
+        Any attributes you don't specify will remain unchanged.
+
+        Returns 422 Bad Request error if trying to update an externally synced record on
+        attributes other than: alert, description, quick_notes
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        Update an organization by id
+
+    .PARAMETER filter_id
+        Filter by an organization id
+
+    .PARAMETER filter_name
+        Filter by an organization name
+
+    .PARAMETER filter_organization_type_id
+        Filter by an organization type id
+
+    .PARAMETER filter_organization_status_id
+        Filter by an organization status id
+
+    .PARAMETER filter_created_at
+        Filter by when an organization created
+
+    .PARAMETER filter_updated_at
+        Filter by when an organization updated
+
+    .PARAMETER filter_my_glue_account_id
+        Filter by a MyGlue id
+
+    .PARAMETER filter_exclude_id
+        Filter to excluded a certain organization id
+
+    .PARAMETER filter_exclude_name
+        Filter to excluded a certain organization name
+
+    .PARAMETER filter_exclude_organization_type_id
+        Filter to excluded a certain organization type id
+
+    .PARAMETER filter_exclude_organization_status_id
+        Filter to excluded a certain organization status id
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueOrganizations -id 8765309 -data $json_object
+
+        Updates an organization with the structured JSON object.
+
+    .EXAMPLE
+        Set-ITGlueOrganizations -filter_organization_status_id 12345 -data $json_object
+
+        Updates all defined organization with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#organizations-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'update')]
     Param (
         [Parameter(ParameterSetName = 'update')]
@@ -219,7 +431,75 @@ function Set-ITGlueOrganizations {
     return Invoke-ITGlueRequest -Method PATCH -ResourceURI $resource_uri -Data $data -QueryParams $query_params
 }
 
+
+
 function Remove-ITGlueOrganizations {
+<#
+    .SYNOPSIS
+        Deletes one or more organizations
+
+    .DESCRIPTION
+        The Remove-ITGlueOrganizations cmdlet marks organizations identified by the
+        specified organization IDs for deletion
+
+        Because it can be a long procedure to delete organizations,
+        removal from the system may not happen immediately.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER filter_id
+        Filter by an organization id
+
+    .PARAMETER filter_name
+        Filter by an organization name
+
+    .PARAMETER filter_organization_type_id
+        Filter by an organization type id
+
+    .PARAMETER filter_organization_status_id
+        Filter by an organization status id
+
+    .PARAMETER filter_created_at
+        Filter by when an organization created
+
+    .PARAMETER filter_updated_at
+        Filter by when an organization updated
+
+    .PARAMETER filter_my_glue_account_id
+        Filter by a MyGlue id
+
+    .PARAMETER filter_exclude_id
+        Filter to excluded a certain organization id
+
+    .PARAMETER filter_exclude_name
+        Filter to excluded a certain organization name
+
+    .PARAMETER filter_exclude_organization_type_id
+        Filter to excluded a certain organization type id
+
+    .PARAMETER filter_exclude_organization_status_id
+        Filter to excluded a certain organization status id
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Remove-ITGlueOrganizations -data $json_object
+
+        Deletes all defined organization with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#organizations-bulk-destroy
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'bulk_destroy')]
     Param (
         [Parameter(ParameterSetName = 'bulk_destroy')]

--- a/ITGlueAPI/Resources/PasswordCategories.ps1
+++ b/ITGlueAPI/Resources/PasswordCategories.ps1
@@ -1,4 +1,35 @@
 function New-ITGluePasswordCategories {
+<#
+    .SYNOPSIS
+        Creates a password category
+
+    .DESCRIPTION
+        The New-ITGluePasswordCategories cmdlet creates a new password category
+        in your account.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGluePasswordCategories -data $json_object
+
+        Creates a new password category with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#password-categories-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         $data
@@ -10,6 +41,65 @@ function New-ITGluePasswordCategories {
 }
 
 function Get-ITGluePasswordCategories {
+<#
+    .SYNOPSIS
+        List or show all password categories
+
+    .DESCRIPTION
+        The Get-ITGluePasswordCategories cmdlet returns a list of password categories
+        or the details of a single password category in your account.
+
+        This function can call the following endpoints:
+            Index = /password_categories
+
+            Show =  /password_categories/:id
+
+    .PARAMETER filter_name
+        Filter by a password category name
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'created_at', 'updated_at', `
+        '-name', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Get a password category by id
+
+    .EXAMPLE
+        Get-ITGluePasswordCategories
+
+        Returns the first 50 password category results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGluePasswordCategories -id 12345
+
+        Returns the password category with the defined id
+
+    .EXAMPLE
+        Get-ITGluePasswordCategories -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for password categories
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#password-categories-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]
@@ -53,6 +143,40 @@ function Get-ITGluePasswordCategories {
 }
 
 function Set-ITGluePasswordCategories {
+<#
+    .SYNOPSIS
+        Updates a password category
+
+    .DESCRIPTION
+        The Set-ITGluePasswordCategories cmdlet updates a password category
+        in your account.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        Update a password category by id
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGluePasswordCategories -id 8756309 -data $json_object
+
+        Updates the defined password category with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#password-categories-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         [Int64]$id,

--- a/ITGlueAPI/Resources/Passwords.ps1
+++ b/ITGlueAPI/Resources/Passwords.ps1
@@ -1,4 +1,63 @@
 function New-ITGluePasswords {
+<#
+    .SYNOPSIS
+        Creates oen or more a passwords
+
+    .DESCRIPTION
+        The New-ITGluePasswords cmdlet creates one or more passwords
+        under the organization specified in the ID parameter.
+
+        To show passwords your API key needs to have the "Password Access" permission
+
+        You can create general and embedded passwords with this endpoint
+
+        If the resource-id and resource-type attributes are NOT provided, IT Glue assumes
+        the password is a general password.
+
+        If the resource-id and resource-type attributes are provided, IT Glue assumes
+        the password is an embedded password.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER organization_id
+        A valid organization Id in your account
+
+    .PARAMETER show_password
+        Define if the password should be shown or not
+
+        By default ITGlue hides the passwords from the returned data
+        and this function enables the password for display.
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGluePasswords -organization_id 8756309 -data $json_object
+
+        Creates a new password in the defined organization with the structured JSON object.
+
+        The password IS returned in the results
+
+    .EXAMPLE
+        New-ITGluePasswords -organization_id 8756309 -show_password $false -data $json_object
+
+        Creates a new password in the defined organization with the structured JSON object.
+
+        The password is NOT returned in the results
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#passwords-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Nullable[Int64]]$organization_id = $null,
 
@@ -19,7 +78,107 @@ function New-ITGluePasswords {
     return Invoke-ITGlueRequest -Method POST -ResourceURI $resource_uri -Data $data -QueryParams $query_params
 }
 
+
+
 function Get-ITGluePasswords {
+<#
+    .SYNOPSIS
+        List or show all passwords
+
+    .DESCRIPTION
+        The Get-ITGluePasswords cmdlet returns a list of passwords for all organizations,
+        a specified organization, or the details of a single password.
+
+        To show passwords your API key needs to have the "Password Access" permission
+
+        This function can call the following endpoints:
+            Index = /passwords
+                    /organizations/:organization_id/relationships/passwords
+
+            Show =  /passwords/:id
+                    /organizations/:organization_id/relationships/passwords/:id
+
+    .PARAMETER organization_id
+        A valid organization Id in your account
+
+    .PARAMETER filter_id
+        Filter by password id
+
+    .PARAMETER filter_name
+        Filter by password name
+
+    .PARAMETER filter_archived
+        Filter by if the password is archived
+
+    .PARAMETER filter_organization_id
+        Filter for passwords by organization id
+
+    .PARAMETER filter_password_category_id
+        Filter by passwords category id
+
+    .PARAMETER filter_url
+        Filter by password url
+
+    .PARAMETER filter_cached_resource_name
+        Filter by a passwords cached resource name
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'username', 'id', 'created_at', 'updated-at', `
+        '-name', '-username', '-id', '-created_at', '-updated-at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Get a password by id
+
+    .PARAMETER show_password
+        Returns the password in the results
+
+    .PARAMETER include
+        Include specified assets
+
+        Allowed values(Index):
+        'attachments', 'rotatable_password', 'updater', 'user_resource_accesses',
+        'group_resource_accesses'
+
+        Allowed values(Show):
+        'attachments', 'rotatable_password', 'updater', 'user_resource_accesses',
+        'group_resource_accesses', 'recent_versions', 'related_items', 'authorized_users'
+
+    .EXAMPLE
+        Get-ITGluePasswords
+
+        Returns the first 50 password results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGluePasswords -id 12345
+
+        Returns the password with the defined id
+
+    .EXAMPLE
+        Get-ITGluePasswords -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for passwords
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#passwords-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]
@@ -122,7 +281,63 @@ function Get-ITGluePasswords {
     return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
 }
 
+
+
 function Set-ITGluePasswords {
+<#
+    .SYNOPSIS
+        Updates one or more passwords
+
+    .DESCRIPTION
+        The Set-ITGluePasswords cmdlet updates the details of an
+        existing password or the details of multiple passwords.
+
+        To show passwords your API key needs to have the "Password Access" permission
+
+        Any attributes you don't specify will remain unchanged.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER organization_id
+        A valid organization Id in your account
+
+    .PARAMETER id
+        Update a password by id
+
+    .PARAMETER show_password
+        Define if the password should be shown or not
+
+        By default ITGlue hides the passwords from the returned data
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGluePasswords -id 8756309 -data $json_object
+
+        Updates the password in the defined organization with the structured JSON object.
+
+        The password is NOT returned in the results
+
+    .EXAMPLE
+        Set-ITGluePasswords -id 8756309 -show_password $true -data $json_object
+
+        Updates the password in the defined organization with the structured JSON object.
+
+        The password IS returned in the results
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#passwords-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'update')]
     Param (
         [Parameter(ParameterSetName = 'update')]
@@ -151,7 +366,60 @@ function Set-ITGluePasswords {
     return Invoke-ITGlueRequest -Method PATCH -ResourceURI $resource_uri -Data $data -QueryParams $query_params
 }
 
+
+
 function Remove-ITGluePasswords {
+<#
+    .SYNOPSIS
+        Deletes one or more passwords
+
+    .DESCRIPTION
+        The Remove-ITGluePasswords cmdlet destroys one or more
+        passwords specified by ID.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        Delete a password by id
+
+    .PARAMETER filter_id
+        Filter by password id
+
+    .PARAMETER filter_name
+        Filter by password name
+
+    .PARAMETER filter_organization_id
+        Filter for passwords by organization id
+
+    .PARAMETER filter_password_category_id
+        Filter by passwords category id
+
+    .PARAMETER filter_url
+        Filter by password url
+
+    .PARAMETER filter_cached_resource_name
+        Filter by a passwords cached resource name
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Remove-ITGluePasswords -id 8756309
+
+        Deletes the defined password
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#passwords-destroy
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'destroy')]
     Param (
         [Parameter(ParameterSetName = 'destroy')]

--- a/ITGlueAPI/Resources/Platforms.ps1
+++ b/ITGlueAPI/Resources/Platforms.ps1
@@ -1,4 +1,64 @@
 function Get-ITGluePlatforms {
+<#
+    .SYNOPSIS
+        List or show all platforms.
+
+    .DESCRIPTION
+        The Get-ITGluePlatforms cmdlet returns a list of supported platforms
+        or the details of a single platform from your account.
+
+        This function can call the following endpoints:
+            Index = /platforms
+
+            Show =  /platforms/:id
+
+    .PARAMETER filter_name
+        Filter by platform name
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'id', 'created_at', 'updated_at', `
+        '-name', '-id', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Get a platform by id
+
+    .EXAMPLE
+        Get-ITGluePlatforms
+
+        Returns the first 50 platform results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGluePlatforms -id 12345
+
+        Returns the platform with the defined id
+
+    .EXAMPLE
+        Get-ITGluePlatforms -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for platforms
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#platforms-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]

--- a/ITGlueAPI/Resources/Regions.ps1
+++ b/ITGlueAPI/Resources/Regions.ps1
@@ -1,4 +1,74 @@
 function Get-ITGlueRegions {
+<#
+    .SYNOPSIS
+        List or show all regions
+
+    .DESCRIPTION
+        The Get-ITGlueRegions cmdlet returns a list of supported regions
+        or the details of a single support region.
+
+        This function can call the following endpoints:
+            Index = /regions
+                    /countries/:id/relationships/regions
+
+            Show =  /regions/:id
+                    /countries/:id/relationships/regions/:id
+
+    .PARAMETER country_id
+        Get regions by country id
+
+    .PARAMETER filter_name
+        Filter by region name
+
+    .PARAMETER filter_iso
+        Filter by region iso abbreviation
+
+    .PARAMETER filter_country_id
+        Filter by country id
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'id', 'created_at', 'updated_at', `
+        '-name', '-id', '-created_at', '-updated_at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Get a region by id
+
+    .EXAMPLE
+        Get-ITGlueRegions
+
+        Returns the first 50 region results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueRegions -id 12345
+
+        Returns the region with the defined id
+
+    .EXAMPLE
+        Get-ITGlueRegions -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for regions
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#regions-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]

--- a/ITGlueAPI/Resources/RelatedItems.ps1
+++ b/ITGlueAPI/Resources/RelatedItems.ps1
@@ -1,4 +1,51 @@
 function New-ITGlueRelatedItems {
+<#
+    .SYNOPSIS
+        Creates one or more related items
+
+    .DESCRIPTION
+        The New-ITGlueRelatedItems cmdlet creates one or more related items.
+
+        The create action is directional from source item to destination item(s).
+
+        The source item is the item that matches the resource_type and resource_id in the URL.
+
+        The destination item(s) are the items that match the destination_type
+        and destination_id in the JSON object.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER resource_type
+        The resource type of the parent resource
+
+        Allowed values:
+        'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents', `
+        'domains', 'locations', 'passwords', 'ssl_certificates', 'flexible_assets', 'tickets'
+
+    .PARAMETER resource_id
+        The resource id of the parent resource.
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        New-ITGlueRelatedItems -resource_type passwords -resource_id 8756309 -data $json_object
+
+        Creates a new related password to the defined resource id with the structured
+        JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#related-items-create
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $true)]
@@ -18,7 +65,56 @@ function New-ITGlueRelatedItems {
     return Invoke-ITGlueRequest -Method POST -ResourceURI $resource_uri -Data $data
 }
 
+
+
 function Set-ITGlueRelatedItems {
+<#
+    .SYNOPSIS
+        Updates a related item for a particular resource
+
+    .DESCRIPTION
+        The Set-ITGlueRelatedItems cmdlet updates a related item for
+        a particular resource.
+
+        Only the related item notes that are displayed on the
+        asset view screen can be changed.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER resource_type
+        The resource type of the parent resource
+
+        Allowed values:
+        'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents', `
+        'domains', 'locations', 'passwords', 'ssl_certificates', 'flexible_assets', 'tickets'
+
+    .PARAMETER resource_id
+        The resource id of the parent resource.
+
+    .PARAMETER id
+        The id of the related item
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueRelatedItems -resource_type passwords -resource_id 8756309 -id 12345 -data $json_object
+
+        Updates the defined related item on the defined resource with the structured
+        JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#related-items-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $true)]
@@ -42,7 +138,50 @@ function Set-ITGlueRelatedItems {
     return Invoke-ITGlueRequest -Method PATCH -ResourceURI $resource_uri -Data $data
 }
 
+
+
 function Remove-ITGlueRelatedItems {
+<#
+    .SYNOPSIS
+        Deletes one or more related items
+
+    .DESCRIPTION
+        The Remove-ITGlueRelatedItems cmdlet deletes one or more specified
+        related items
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER resource_type
+        The resource type of the parent resource
+
+        Allowed values:
+        'checklists', 'checklist_templates', 'configurations', 'contacts', 'documents', `
+        'domains', 'locations', 'passwords', 'ssl_certificates', 'flexible_assets', 'tickets'
+
+    .PARAMETER resource_id
+        The id of the related item
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Remove-ITGlueRelatedItems -resource_type passwords -resource_id 8756309 -data $json_object
+
+        Deletes the defined related item on the defined resource with the structured
+        JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#related-items-bulk-destroy
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $true)]

--- a/ITGlueAPI/Resources/UserMetrics.ps1
+++ b/ITGlueAPI/Resources/UserMetrics.ps1
@@ -1,4 +1,73 @@
 function Get-ITGlueUserMetrics {
+<#
+    .SYNOPSIS
+        Lists all user metrics
+
+    .DESCRIPTION
+        The Get-ITGlueUserMetrics cmdlet lists all user metrics
+
+    .PARAMETER filter_user_id
+        Filter by user id
+
+    .PARAMETER filter_organization_id
+        Filter for users metrics by organization id
+
+    .PARAMETER filter_resource_type
+        Filter for user metrics by resource type
+
+        Example:
+            'Configurations','Passwords','Active Directory'
+
+    .PARAMETER filter_date
+        Filter for users metrics by a date range
+
+        The specified string must be a date range and comma-separated `start_date, end_date`.
+        The dates are UTC.
+
+        Use `*` for unspecified `start_date` or `end_date`.
+
+        Date ranges longer than a week may be disallowed for performance reasons.
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'id', 'created', 'viewed', 'edited', 'deleted', 'date', `
+        '-id', '-created', '-viewed', '-edited', '-deleted', '-date'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .EXAMPLE
+        Get-ITGlueUserMetrics
+
+        Returns the first 50 user metric results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueUserMetrics -filter_user_id 12345
+
+        Returns the user metric for the user with the defined id
+
+    .EXAMPLE
+        Get-ITGlueUserMetrics -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for user metrics
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#accounts-user-metrics-daily-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]

--- a/ITGlueAPI/Resources/Users.ps1
+++ b/ITGlueAPI/Resources/Users.ps1
@@ -1,4 +1,72 @@
 function Get-ITGlueUsers {
+<#
+    .SYNOPSIS
+        List or show all users
+
+    .DESCRIPTION
+        The Get-ITGlueUsers cmdlet returns a list of the users
+        or the details of a single user in your account.
+
+        This function can call the following endpoints:
+            Index = /users
+
+            Show =  /users/:id
+
+    .PARAMETER filter_name
+        Filter by user name
+
+    .PARAMETER filter_email
+        Filter by user email address
+
+    .PARAMETER filter_role_name
+        Filter by a users role
+
+        Allowed values:
+            'Administrator', 'Manager', 'Editor', 'Creator', 'Lite', 'Read-only'
+
+    .PARAMETER sort
+        Sort results by a defined value
+
+        Allowed values:
+        'name', 'email', 'reputation', 'id', 'created_at', 'updated-at', `
+        '-name', '-email', '-reputation', '-id', '-created_at', '-updated-at'
+
+    .PARAMETER page_number
+        Return results starting from the defined number
+
+    .PARAMETER page_size
+        Number of results to return per page
+
+    .PARAMETER id
+        Get a user by id
+
+    .EXAMPLE
+        Get-ITGlueUsers
+
+        Returns the first 50 user results from your ITGlue account
+
+    .EXAMPLE
+        Get-ITGlueUsers -id 12345
+
+        Returns the user with the defined id
+
+    .EXAMPLE
+        Get-ITGlueUsers -page_number 2 -page_size 10
+
+        Returns the first 10 results from the second page for users
+        in your ITGlue account
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#accounts-users-index
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
     [CmdletBinding(DefaultParameterSetName = 'index')]
     Param (
         [Parameter(ParameterSetName = 'index')]
@@ -54,7 +122,43 @@ function Get-ITGlueUsers {
     return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
 }
 
+
+
 function Set-ITGlueUsers {
+<#
+    .SYNOPSIS
+        Updates the name or profile picture of an existing user.
+
+    .DESCRIPTION
+        The Set-ITGlueUsers cmdlet updates the name or profile picture (avatar)
+        of an existing user.
+
+        Examples of JSON objects can be found under ITGlues developer documentation
+            https://api.itglue.com/developer
+
+    .PARAMETER id
+        Update by user id
+
+    .PARAMETER data
+        JSON object or array depending on bulk changes or not
+
+    .EXAMPLE
+        Set-ITGlueUsers -id 8756309 -data $json_object
+
+        Updates the defined user with the structured JSON object.
+
+    .NOTES
+        N\A
+
+    .LINK
+        https://api.itglue.com/developer/#accounts-users-update
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+#>
+
+    [cmdletbinding()]
     Param (
         [Parameter(Mandatory = $true)]
         [Int64]$id,

--- a/ITGlueAPI/Tests/APIKey.Tests.ps1
+++ b/ITGlueAPI/Tests/APIKey.Tests.ps1
@@ -1,24 +1,100 @@
-#Requires -Modules Pester
+<#
+    .SYNOPSIS
+        Pester tests for functions in the "APIKey.ps1" file
 
-# Obtain name of this file
-$ThisFile = $PSCommandPath -replace '\.Tests\.ps1$'
-$ThisFileName = $ThisFile | Split-Path -Leaf
+    .DESCRIPTION
+        Pester tests for functions in the APIKey.ps1 file which
+        is apart of the ITGlueAPI module.
 
-Describe "Tests" {
-    Context "Test $ThisFileName Functions" {
-        It "ITGlue_API_Key should intially be empty or null" {
+    .EXAMPLE
+        Invoke-Pester -Path .\Tests\APIKey.Tests.ps1
+
+        Runs a pester test against "APIKey.Tests.ps1" and outputs simple test results.
+
+    .EXAMPLE
+        Invoke-Pester -Path .\Tests\APIKey.Tests.ps1 -Output Detailed
+
+        Runs a pester test against "APIKey.Tests.ps1" and outputs detailed test results.
+
+    .NOTES
+        Build out more robust, logical, & scalable pester tests.
+        Look into BeforeAll as it is not working as expected with this test
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+#>
+
+#Requires -Version 5.0
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+#Requires -Modules @{ ModuleName='ITGlueAPI'; ModuleVersion='2.1.0' }
+
+# General variables
+    $FullFileName = $MyInvocation.MyCommand.Name
+    #$ThisFile = $PSCommandPath -replace '\.Tests\.ps1$'
+    #$ThisFileName = $ThisFile | Split-Path -Leaf
+
+
+Describe "Testing [ *-ITGlueAPIKey ] functions with [ $FullFileName ]" {
+
+    Context "[ Add-ITGlueAPIKey ] testing functions" {
+
+        It "The ITGlue_API_Key variable should initially be empty or null" {
+            Remove-ITGlueAPIKey
             $ITGlue_API_Key | Should -BeNullOrEmpty
         }
-        It "Add-ITGlueAPIKey called with parameter ITGlue_API_Key should not be empty" {
-            Add-ITGlueAPIKey -Api_Key "ITGAPIKEY"
+
+        It "[ Add-ITGlueAPIKey ] should accept a value from the pipeline" {
+            "MyApiKey" | Add-ITGlueAPIKey
             Get-ITGlueAPIKey | Should -Not -BeNullOrEmpty
         }
-        It "Get-ITGlueAPIKey should return a value" {
+
+        It "[ Add-ITGlueAPIKey ] called with parameter -API_Key should not be empty" {
+            Add-ITGlueAPIKey -Api_Key "MyApiKey"
             Get-ITGlueAPIKey | Should -Not -BeNullOrEmpty
-        }
-        It "Remove-ITGlueAPIKey should remove the ITGlue_API_Key variable" {
-            Remove-ITGlueAPIKey
-            Get-ITGlueAPIKey | Should -BeNullOrEmpty
         }
     }
+
+    Context "[ Get-ITGlueAPIKey ] testing functions" {
+
+        It "[ Get-ITGlueAPIKey ] should return a value" {
+            Get-ITGlueAPIKey | Should -Not -BeNullOrEmpty
+        }
+
+        It "[ Get-ITGlueAPIKey ] should be a SecureString (From PipeLine)" {
+            "MyApiKey" | Add-ITGlueAPIKey
+            Get-ITGlueAPIKey | Should -BeOfType SecureString
+        }
+
+        It "[ Get-ITGlueAPIKey ] should be a SecureString (With Parameter)" {
+            Add-ITGlueAPIKey -Api_Key "MyApiKey"
+            Get-ITGlueAPIKey | Should -BeOfType SecureString
+        }
+
+    }
+
+    Context "[ Remove-ITGlueAPIKey ] testing functions" {
+
+        It "[ Remove-ITGlueAPIKey ] should remove the ITGlue_API_Key variable" {
+            Add-ITGlueAPIKey -Api_Key "MyApiKey"
+            Remove-ITGlueAPIKey
+            $ITGlue_API_Key | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "[ Test-ITGlueAPIKey ] testing functions" {
+
+        It "[ Test-ITGlueAPIKey ] without an API key should fail to authenticate" {
+            Remove-ITGlueAPIKey -WarningAction SilentlyContinue
+            $Value = Test-ITGlueAPIKey -WarningAction SilentlyContinue
+            $Value.Message | Should -BeLike '*password" is null*'
+        }
+
+        It "[ Test-ITGlueAPIKey ] with an incorrect API key should fail to authenticate" {
+            Add-ITGlueAPIKey -Api_Key "MyApiKey"
+            $Value = Test-ITGlueAPIKey -WarningAction SilentlyContinue
+            $Value.Message | Should -BeLike '*403*'
+        }
+
+    }
+
 }

--- a/ITGlueAPI/Tests/BaseURI.Tests.ps1
+++ b/ITGlueAPI/Tests/BaseURI.Tests.ps1
@@ -1,35 +1,75 @@
-#Requires -Modules Pester
+<#
+    .SYNOPSIS
+        Pester tests for functions in the "BaseURI.ps1" file
 
-# Obtain name of this file
-$ThisFile = $PSCommandPath -replace '\.Tests\.ps1$'
-$ThisFileName = $ThisFile | Split-Path -Leaf
+    .DESCRIPTION
+        Pester tests for functions in the "BaseURI.ps1" file which
+        is apart of the ITGlueAPI module.
 
-Describe "Tests" {
-    Context "Test $ThisFileName Functions" {
-        It "Add-ITGlueBaseURI without parameter should return a valid URI" {
-            Add-ITGlueBaseURI
-            $BaseURI = Get-ITGlueBaseURI
-            $BaseURI | Should -Be 'https://api.itglue.com'
+    .EXAMPLE
+        Invoke-Pester -Path .\Tests\BaseURI.Tests.ps1
+
+        Runs a pester test against "BaseURI.Tests.ps1" and outputs simple test results.
+
+    .EXAMPLE
+        Invoke-Pester -Path .\Tests\BaseURI.Tests.ps1 -Output Detailed
+
+        Runs a pester test against "BaseURI.Tests.ps1" and outputs detailed test results.
+
+    .NOTES
+        Build out more robust, logical, & scalable pester tests.
+        Look into BeforeAll as it is not working as expected with this test
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+#>
+
+#Requires -Version 5.0
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+#Requires -Modules @{ ModuleName='ITGlueAPI'; ModuleVersion='2.1.0' }
+
+# General variables
+    $FullFileName = $MyInvocation.MyCommand.Name
+    #$ThisFile = $PSCommandPath -replace '\.Tests\.ps1$'
+    #$ThisFileName = $ThisFile | Split-Path -Leaf
+
+
+Describe " Testing [ *-ITGlueBaseURI } functions with [ $FullFileName ]" {
+
+    Context "[ Add-ITGlueBaseURI ] testing functions" {
+
+        It "[ Add-ITGlueBaseURI ] should accept a value from the pipeline" {
+            'https://itglue.com' | Add-ITGlueBaseURI
+            Get-ITGlueBaseURI | Should -Be 'https://itglue.com'
         }
-        It "Add-ITGlueBaseURI parameter US should return a valid URI" {
-            Add-ITGlueBaseURI -data_center 'US'
-            $BaseURI = Get-ITGlueBaseURI
-            $BaseURI | Should -Be 'https://api.itglue.com'
+
+        It "[ Add-ITGlueBaseURI ] with parameter -base_uri should return a valid URI" {
+            Add-ITGlueBaseURI -base_uri 'https://itglue.com'
+            Get-ITGlueBaseURI | Should -Be 'https://itglue.com'
         }
-        It "Add-ITGlueBaseURI parameter EU should return a valid URI" {
-            Add-ITGlueBaseURI -data_center 'EU'
-            $BaseURI = Get-ITGlueBaseURI
-            $BaseURI | Should -Be 'https://api.eu.itglue.com'
+
+        It "[ Add-ITGlueBaseURI ] a trailing / from a -base_uri should be removed" {
+            Add-ITGlueBaseURI -base_uri 'https://itglue.com/'
+            Get-ITGlueBaseURI | Should -Be 'https://itglue.com'
         }
-        It "Add-ITGlueBaseURI parameter AU should return a valid URI" {
-            Add-ITGlueBaseURI -data_center 'AU'
-            $BaseURI = Get-ITGlueBaseURI
-            $BaseURI | Should -Be 'https://api.au.itglue.com'
-        }
-        It "Remove-ITGlueBaseURI should remove the variable" {
-            Remove-ITGlueBaseURI
-            $BaseURI = Get-ITGlueBaseURI
-            $BaseURI | Should -BeNullOrEmpty
+
+    }
+
+    Context "[ Get-ITGlueBaseURI ] testing functions" {
+
+        It "[ Get-ITGlueBaseURI ] value should be a string" {
+            Add-ITGlueBaseURI -base_uri 'https://itglue.com'
+            Get-ITGlueBaseURI | Should -BeOfType string
         }
     }
+
+    Context "[ Remove-ITGlueBaseURI ] testing functions" {
+
+        It "[ Remove-ITGlueBaseURI ] should remove the variable" {
+            Add-ITGlueBaseURI -base_uri 'https://itglue.com'
+            Remove-ITGlueBaseURI
+            $ITGlue_Base_URI | Should -BeNullOrEmpty
+        }
+    }
+
 }

--- a/ITGlueAPI/Tests/HelpComment.Tests.ps1
+++ b/ITGlueAPI/Tests/HelpComment.Tests.ps1
@@ -1,0 +1,137 @@
+<#
+    .SYNOPSIS
+        Pester tests looking for help comments in all ITGlueAPI module functions
+
+    .DESCRIPTION
+        Pester tests looking for help comments in all ITGlueAPI module functions
+
+    .EXAMPLE
+        Invoke-Pester -Path .\Tests\HelpComment.Tests.ps1
+
+        Runs a pester test against "HelpComment.Tests.ps1" and outputs simple test results.
+
+    .EXAMPLE
+        Invoke-Pester -Path .\Tests\HelpComment.Tests.ps1 -Output Detailed
+
+        Runs a pester test against "HelpComment.Tests.ps1" and outputs detailed test results.
+
+    .NOTES
+        Build out more robust, logical, & scalable pester tests.
+        Huge thank you to LazyWinAdmin, Vexx32, & JeffBrown for their blog posts!
+
+    .LINK
+        https://github.com/itglue/powershellwrapper
+
+    .LINK
+        https://vexx32.github.io/2020/07/08/Verify-Module-Help-Pester/
+        https://lazywinadmin.com/2016/05/using-pester-to-test-your-comment-based.html
+        https://jeffbrown.tech/getting-started-with-pester-testing-in-powershell/
+
+#>
+
+#Requires -Version 5.0
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+#Requires -Modules @{ ModuleName='ITGlueAPI'; ModuleVersion='2.1.0' }
+
+$ModuleName = 'ITGlueAPI'
+
+BeforeAll {
+    $ModuleName = 'ITGlueAPI'
+    Import-Module $ModuleName
+}
+
+
+Describe "Testing [ $ModuleName ] functions for comment based help" -Tags 'Module' {
+
+    #Region Discovery
+
+    # The module will need to be imported during Discovery since we're using it to generate test cases / Context blocks
+    Import-Module $ModuleName
+
+    $ShouldProcessParameters = 'WhatIf', 'Confirm'
+
+    # Generate command list for generating Context / TestCases
+    $Module = Get-Module $ModuleName
+    $CommandList = @(
+        $Module.ExportedFunctions.Keys
+        $Module.ExportedCmdlets.Keys
+    )
+
+    #EndRegion Discovery
+
+    ForEach ($Command in $CommandList) {
+        Context "[ $Command ] - Comment Based Help" {
+
+            #Region Discovery
+
+                $Help = @{ Help = Get-Help -Name $Command -Full | Select-Object -Property * }
+
+                $Parameters = Get-Help -Name $Command -Parameter * -ErrorAction Ignore |
+                    Where-Object { $_.Name -and $_.Name -notin $ShouldProcessParameters } |
+                    ForEach-Object { @{
+                                        Name        = $_.name
+                                        Description = $_.Description.Text
+                                    }
+                    }
+
+                $Ast = @{
+                    # Ast will be $null if the command is a compiled cmdlet
+                    Ast        = (Get-Content -Path "function:/$Command" -ErrorAction Ignore).Ast
+                    Parameters = $Parameters
+                }
+
+                $Examples = $Help.Help.Examples.Example |
+                    ForEach-Object {    @{
+                                            Example = $_
+                                            Title = $_.title -replace '-',''
+                                        }
+                    }
+
+            #EndRegion Discovery
+
+            It "[ $Command ] has comment based help" -TestCases $Help {
+                $Help | Should -Not -BeNullOrEmpty
+            }
+
+            It "[ $Command ] contains a synopsis" -TestCases $Help {
+                $Help.Synopsis | Should -Not -BeNullOrEmpty
+            }
+
+            It "[ $Command ] contains a description" -TestCases $Help {
+                $Help.Description | Should -Not -BeNullOrEmpty
+            }
+
+            It "[ $Command ] contains an example" -TestCases $Help {
+                $Help.Examples | Should -Not -BeNullOrEmpty
+            }
+
+            It "[ $Command ] contains a note" -TestCases $Help {
+                $Notes = $Help.AlertSet.Alert.Text -split '\n'
+                $Notes[0].Trim() | Should -Not -BeNullOrEmpty
+            }
+
+            It "[ $Command ] contains a link" -TestCases $Help {
+                $Help.relatedLinks | Should -Not -BeNullOrEmpty
+            }
+
+            # This will be skipped for compiled commands ($Ast.Ast will be $null)
+            It "[ $Command ] has a help entry for all parameters" -TestCases $Ast -Skip:(-not ($Parameters -and $Ast.Ast)) {
+                @($Parameters).Count | Should -Be $Ast.Body.ParamBlock.Parameters.Count -Because 'the number of parameters in the help should match the number in the function script'
+            }
+
+            # -<Name> is a pester variable
+            It "[ $Command ] has a description for parameter [ -<Name> ]" -TestCases $Parameters -Skip:(-not $Parameters) {
+                $Description | Should -Not -BeNullOrEmpty -Because "parameter $Name should have a description"
+            }
+
+            It "[ $Command ] has at least one usage example" -TestCases $Help {
+                $Help.Examples.Example.Code.Count | Should -BeGreaterOrEqual 1
+            }
+
+            # <title> is a pester variable
+            It "[ $Command ] lists a description for: [ <title> ]" -TestCases $Examples {
+                $Example.Remarks | Should -Not -BeNullOrEmpty -Because "example $($Example.Title) should have a description!"
+            }
+        }
+    }
+}

--- a/ITGlueAPI/Tests/ITGlueAPI.Tests.ps1
+++ b/ITGlueAPI/Tests/ITGlueAPI.Tests.ps1
@@ -1,149 +1,307 @@
-#Requires -Modules Pester
+<#
+    .SYNOPSIS
+        Pester tests for the ITGlueAPI module manifest file.
 
-# Obtain name of this module by parsing name of test file (ITGlueAPI\Tests\ITGlueAPI.Tests.ps1)
-$ThisModule = $PSCommandPath -replace '\.Tests\.ps1$'
-$ThisModuleName = $ThisModule | Split-Path -Leaf
+    .DESCRIPTION
+        Pester tests for the ITGlueAPI module manifest file.
 
-# Obtain path of the module based on location of test file (ITGlueAPI\Tests\ITGlueAPI.Tests.ps1)
-$ThisModulePath = Split-Path (Split-Path -Parent $PSCommandPath) -Parent
+    .EXAMPLE
+        Invoke-Pester -Path .\Tests\ITGlueAPI.Tests.ps1
 
-# Make sure one or multiple versions of the module are not loaded
-Get-Module -Name $ThisModuleName | Remove-Module
+        Runs a pester test against "ITGlueAPI.Tests.ps1" and outputs simple test results.
 
-# Credit - borrowed with care from http://www.lazywinadmin.com/2016/05/using-pester-to-test-your-manifest-file.html and modified as needed
-# Manifest file path
-$ManifestFile = "$ThisModulePath\$ThisModuleName.psd1"
+    .EXAMPLE
+        Invoke-Pester -Path .\Tests\ITGlueAPI.Tests.ps1 -Output Detailed
 
-# Import the module and store the information about the module
-$ModuleInformation = Import-module -Name $ManifestFile -PassThru
+        Runs a pester test against "ITGlueAPI.Tests.ps1" and outputs detailed test results.
 
-# Internal Files
-$InternalDirectoryFiles = (
-    'APIKey.ps1',
-    'BaseURI.ps1',
-    'ModuleSettings.ps1'
-)
+    .NOTES
+        Build out more robust, logical, & scalable pester tests.
+        Huge thank you to LazyWinAdmin, Vexx32, & JeffBrown for their blog posts!
 
-# Resource Files
-$ResourceDirectoryFiles = (
-    'Attachments.ps1',
-    'ConfigurationInterfaces.ps1',
-    'Configurations.ps1',
-    'ConfigurationStatuses.ps1',
-    'ConfigurationTypes.ps1',
-    'Contacts.ps1',
-    'ContactTypes.ps1',
-    'Countries.ps1',
-    'Documents.ps1',
-    'Domains.ps1',
-    'Expirations.ps1',
-    'FlexibleAssetFields.ps1',
-    'FlexibleAssets.ps1',
-    'FlexibleAssetTypes.ps1',
-    'Groups.ps1',
-    'Locations.ps1',
-    'Logs.ps1',
-    'Manufacturers.ps1',
-    'Models.ps1',
-    'OperatingSystems.ps1',
-    'Organizations.ps1',
-    'OrganizationStatuses.ps1',
-    'OrganizationTypes.ps1',
-    'PasswordCategories.ps1',
-    'Passwords.ps1',
-    'Platforms.ps1',
-    'Regions.ps1',
-    'UserMetrics.ps1',
-    'Users.ps1'
-)
+    .LINK
+        https://github.com/itglue/powershellwrapper
 
-# Manifest Elements
-$ManifestFileElements = (
-    'RootModule',
-    'Author',
-    'CompanyName',
-    'Description',
-    'Copyright',
-    'PowerShellVersion',
-    'NestedModules',
-    'HelpInfoURI'
-)
+    .LINK
+        https://vexx32.github.io/2020/07/08/Verify-Module-Help-Pester/
+        https://lazywinadmin.com/2016/05/using-pester-to-test-your-comment-based.html
+        https://jeffbrown.tech/getting-started-with-pester-testing-in-powershell/
 
-Describe "Module Tests" {
-    Context "Test $ThisModuleName Module" {
-        It "has the root module $ThisModuleName.psm1" {
-            "$ThisModulePath\$ThisModuleName.psm1" | Should Exist
-        }
+#>
 
-        Context "Test Manifest File (.psd1)"{
-            It "Should pass Test-ModuleManifest" {
-                $errors = $null
-                $errors = Test-ModuleManifest -Path $ThisModulePath\$ThisModuleName.psd1 -ErrorAction Stop
-                $errors.Count | Should Be 1
+#Requires -Version 5.0
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+#Requires -Modules @{ ModuleName='ITGlueAPI'; ModuleVersion='2.1.0' }
+
+#Region [ Discovery ]
+
+    #IDK why I have to duplicate this, but it works.
+
+        # Obtain name of this module by parsing name of test file (ITGlueAPI\Tests\ITGlueAPI.Tests.ps1)
+        $ThisModule = $PSCommandPath -replace '\.Tests\.ps1$'
+        $ThisModuleName = $ThisModule | Split-Path -Leaf
+
+        # Obtain path of the module based on location of test file (ITGlueAPI\Tests\ITGlueAPI.Tests.ps1)
+        $ThisModulePath = Split-Path (Split-Path -Parent $PSCommandPath) -Parent
+
+        # Make sure one or multiple versions of the module are not loaded
+        Get-Module -Name $ThisModuleName | Remove-Module
+
+        # Manifest file path
+        $ManifestFile = "$ThisModulePath\$ThisModuleName.psd1"
+
+    BeforeAll {
+
+        $ThisModule = $PSCommandPath -replace '\.Tests\.ps1$'
+        $ThisModuleName = $ThisModule | Split-Path -Leaf
+
+        $ThisModulePath = Split-Path (Split-Path -Parent $PSCommandPath) -Parent
+        $ManifestFile = "$ThisModulePath\$ThisModuleName.psd1"
+
+    }
+
+#EndRegion [ Discovery ]
+
+Describe "[ $ThisModuleName ] testing the module manifest file" {
+
+#Region     [Discovery]
+
+    $ModuleInformation = Import-module -Name $ManifestFile -PassThru
+
+    # Generate command list for generating Context / TestCases
+    $Module = Get-Module -Name $ThisModuleName
+    $ModuleFiles = $ThisModulePath | Get-ChildItem -File -Recurse | Select-Object *
+
+#EndRegion  [Discovery]
+
+    ForEach ($ManifestFileElement in $Module) {
+
+        Context "[ $ThisModuleName ] Manifest File Elements" {
+
+        #Region Discovery
+
+        $Elements = @{ Elements = $Module | Select-Object -Property * }
+
+        #EndRegion Discovery
+
+            It "[ $ThisModuleName ] manifest RootModule is not empty" -TestCases $Elements {
+                $Elements.RootModule | Should -Not -BeNullOrEmpty
             }
 
-            # Credit - borrowed with care from http://www.lazywinadmin.com/2016/05/using-pester-to-test-your-manifest-file.html and modified as needed
-            ForEach ($ManifestFileElement in $ManifestFileElements) {
-                It "Should contains $ManifestFileElement"{
-                    $ModuleInformation.$ManifestFileElement | Should not BeNullOrEmpty
+                It "[ $ThisModuleName ] manifest RootModule has valid data" -TestCases $Elements {
+                    $Elements.RootModule | Should -Be 'ITGlueAPI.psm1'
                 }
+
+            It "[ $ThisModuleName ] manifest ModuleVersion is not empty" -TestCases $Elements {
+                $Elements.Version | Should -Not -BeNullOrEmpty
             }
-        }
 
-        It "$ThisModuleName\Resources directory has functions" {
-            "$ThisModulePath\Resources\*.ps1" | Should Exist
-        }
+                It "[ $ThisModuleName ] manifest ModuleVersion has valid data" -TestCases $Elements {
+                    $Elements.Version | Should -BeGreaterOrEqual '2.1.0'
+                }
 
-        # TODO - Only checking one file currently
-        It "$ThisModuleName is valid PowerShell code" {
-            $psFile = Get-Content -Path "$ThisModulePath\$ThisModuleName.psm1" -ErrorAction Stop
-            $errors = $null
-            $null = [System.Management.Automation.PSParser]::Tokenize($psfile, [ref]$errors)
-            $errors.Count | Should Be 0
+            It "[ $ThisModuleName ] manifest GUID is not empty" -TestCases $Elements {
+                $Elements.GUID | Should -Not -BeNullOrEmpty
+            }
+
+                It "[ $ThisModuleName ] manifest GUID has valid data" -TestCases $Elements {
+                    $Elements.GUID | Should -Be 'f969cff1-3120-4980-8c46-83f2d0bf2521'
+                }
+
+            It "[ $ThisModuleName ] manifest Author is not empty" -TestCases $Elements {
+                $Elements.Author | Should -Not -BeNullOrEmpty
+            }
+
+                It "[ $ThisModuleName ] manifest Author has valid data" -TestCases $Elements {
+                    $Elements.Author | Should -Be 'Caleb Albers'
+                }
+
+            It "[ $ThisModuleName ] manifest CompanyName is not empty" -TestCases $Elements {
+                $Elements.CompanyName | Should -Not -BeNullOrEmpty
+            }
+
+                It "[ $ThisModuleName ] manifest CompanyName has valid data" -TestCases $Elements {
+                    $Elements.CompanyName | Should -Be 'IT Glue'
+                }
+
+            It "[ $ThisModuleName ] manifest Copyright is not empty" -TestCases $Elements {
+                $Elements.Copyright | Should -Not -BeNullOrEmpty
+            }
+
+                It "[ $ThisModuleName ] manifest Copyright has valid data" -TestCases $Elements {
+                    $Elements.Copyright | Should -Be 'https://github.com/itglue/powershellwrapper/blob/master/LICENSE'
+                }
+
+            It "[ $ThisModuleName ] manifest Description is not empty" -TestCases $Elements {
+                $Elements.Description | Should -Not -BeNullOrEmpty
+            }
+
+            It "[ $ThisModuleName ] manifest PowerShellVersion is not empty" -TestCases $Elements {
+                $Elements.PowerShellVersion | Should -Not -BeNullOrEmpty
+            }
+
+                It "[ $ThisModuleName ] manifest PowerShellVersion has valid data" -TestCases $Elements {
+                    $Elements.PowerShellVersion | Should -BeGreaterOrEqual '3.0'
+                }
+
+            It "[ $ThisModuleName ] manifest NestedModules is not empty" -TestCases $Elements {
+                $Elements.NestedModules | Should -Not -BeNullOrEmpty
+            }
+
+                It "[ $ThisModuleName ] manifest NestedModules has valid data" -TestCases $Elements {
+                    ($Elements.NestedModules.Name).Count | Should -Be 33
+                }
+
+            It "[ $ThisModuleName ] manifest FunctionsToExport is not empty" -TestCases $Elements {
+                $Elements.ExportedCommands | Should -Not -BeNullOrEmpty
+            }
+
+                It "[ $ThisModuleName ] manifest FunctionsToExport has valid data" -TestCases $Elements {
+                    ($Elements.ExportedCommands).Count | Should -Be 88
+                }
+
+            It "[ $ThisModuleName ] manifest CmdletsToExport is empty" -TestCases $Elements {
+                ($Elements.ExportedCmdlets).Count |  Should -Be 0
+            }
+
+            It "[ $ThisModuleName ] manifest VariablesToExport is empty" -TestCases $Elements {
+                ($null -ne ($Elements | Select-Object ExportedVariables) -and (($Elements).ExportedVariables).Count -eq 0) | Should -Be $true
+            }
+
+            <#
+            It "[ $ThisModuleName ] manifest AliasesToExport is empty" -TestCases $Elements {
+                ($Elements.ExportedAliases).Count |  Should -Be 0
+            }
+
+            It "[ $ThisModuleName ] manifest Tags is not empty" -TestCases $Elements {
+                $Elements.PrivateData.PSData.Tags | Should -Not -BeNullOrEmpty
+            }
+
+                It "[ $ThisModuleName ] manifest Tags has valid data" -TestCases $Elements {
+                    $Elements.PrivateData.PSData.Tags | Should -Contain 'ITGlue'
+                    ($Elements.PrivateData.PSData.Tags).Count | Should -BeGreaterOrEqual 7
+                }
+            #>
+
+            It "[ $ThisModuleName ] manifest LicenseUri is not empty" -TestCases $Elements {
+                $Elements.LicenseUri | Should -Not -BeNullOrEmpty
+            }
+
+                It "[ $ThisModuleName ] manifest LicenseUri has valid data" -TestCases $Elements {
+                    $Elements.LicenseUri | Should -Be 'https://github.com/itglue/powershellwrapper/blob/master/LICENSE'
+                }
+
+            It "[ $ThisModuleName ] manifest ProjectUri is not empty" -TestCases $Elements {
+                $Elements.ProjectUri  | Should -Not -BeNullOrEmpty
+            }
+
+                It "[ $ThisModuleName ] manifest ProjectUri has valid data" -TestCases $Elements {
+                    $Elements.ProjectUri  | Should -Be 'https://github.com/itglue/powershellwrapper'
+                }
+
+            <#
+            It "[ $ThisModuleName ] manifest IconUri is not empty" -TestCases $Elements {
+                $Elements.IconUri  | Should -Not -BeNullOrEmpty
+            }
+
+            It "[ $ThisModuleName ] manifest ReleaseNotes is not empty" -TestCases $Elements {
+                $Elements.ReleaseNotes  | Should -Not -BeNullOrEmpty
+            }
+
+                It "[ $ThisModuleName ] manifest ReleaseNotes has valid data" -TestCases $Elements {
+                    $Elements.ReleaseNotes  | Should -Be 'https://github.com/itglue/powershellwrapper/blob/main/README.md'
+                }
+
+            It "[ $ThisModuleName ] manifest HelpInfoUri is not empty" -TestCases $Elements {
+                $Elements.HelpInfoUri | Should -Not -BeNullOrEmpty
+            }
+
+                It "[ $ThisModuleName ] manifest HelpInfoUri has valid data" -TestCases $Elements {
+                    ($Elements.HelpInfoUri -like "*ITGlue*") | Should -Be $true
+                }
+            #>
         }
     }
 
-    # Check that Internal files exist
-    ForEach ($InternalFile in $InternalDirectoryFiles) {
-        Context "Test $InternalFile Internal File in .\Internal directory" {
-            It "$InternalFile should exist" {
-                "$ThisModulePath\Internal\$InternalFile" | Should Exist
-            }
-            It "$InternalFile is valid PowerShell code" {
-                $psFile = Get-Content -Path "$ThisModulePath\Internal\$InternalFile" -ErrorAction Stop
-                $errors = $null
-                $null = [System.Management.Automation.PSParser]::Tokenize($psfile, [ref]$errors)
-                $errors.Count | Should Be 0
-            }
-            # Test for test files
-            $InternalFileTest = $InternalFile -replace '\.ps1$'
-            It "$InternalFileTest.Tests.ps1 should exist" {
-                "$InternalFileTest.Tests.ps1" | Should Exist
+    Context "[ $ThisModuleName ] Testing Manifest & Script Modules" {
+
+        It "[ $ThisModuleName ] manifest & script modules are stored in the correct location" {
+            $($ThisModulePath+"\"+$ThisModuleName.psd1) | Should -Exist
+            $($ThisModulePath+"\"+$ThisModuleName.psm1) | Should -Exist
+        }
+
+        It "[ $ThisModuleName ] has functions in the Internal directory" {
+            "$ThisModulePath\Internal\*.ps1" | Should -Exist
+        }
+
+        It "[ $ThisModuleName ] has functions in the Resources directory" {
+            "$ThisModulePath\Resources\*.ps1" | Should -Exist
+        }
+
+        It "[ $ThisModuleName ] has tests in the Tests directory" {
+            "$ThisModulePath\Tests\*Tests.ps1" | Should -Exist
+        }
+
+        It "[ $($ThisModuleName+".psd1")] Should pass Test-ModuleManifest" {
+            $ManifestFile | Test-ModuleManifest -ErrorAction SilentlyContinue
+            $? | Should -Be $true
+        }
+
+        It "[ $($ThisModuleName+".psd1")] Should import PowerShell $ThisModuleName successfully" {
+            $ThisModulePath | Import-Module
+            $? | Should -Be $true
+        }
+
+        #Both $File need to exist for assertion or the value goes null...IDK why
+        Context "[ $ThisModuleName ] Tests directory contains only tests" {
+
+            ForEach ($File in $($ModuleFiles | Where-Object {$_.Directory -like "*Tests*"})) {
+
+                #Region Discovery
+
+                    $File = @{ File = $File }
+
+                #EndRegion Discovery
+
+                    It "[ $ThisModuleName ] Pester test files: $($File.File.Name)" -TestCases $File {
+                        $File = @{ File = $File }
+                        $PesterTestFile = $File.File.Name -replace '\.Tests\.ps1$'
+                        "$($File.File.Directory)\$PesterTestFile.Tests.ps1" | Should -Exist
+                    }
             }
         }
     }
 
-    # Check that Resource files exist
-    ForEach ($ResourceFile in $ResourceDirectoryFiles) {
-        Context "Test $ResourceFile Resource File in .\Resources directory" {
-            It "$ResourceFile should exist" {
-                "$ThisModulePath\Resources\$ResourceFile" | Should Exist
+    Context "[ $ThisModuleName ] Testing for PowerShell file types" {
+        #Region Discovery
+
+        $Files = @{ Files = $ModuleFiles | Select-Object -Property * }
+
+        #EndRegion Discovery
+
+            It "[ $ThisModuleName ] contains only PowerShell files" -TestCases $Files {
+                ($Files | Group-Object Extension).Name.Count | Should -Be 3
             }
-            It "$ResourceFile is valid PowerShell code" {
-                $psFile = Get-Content -Path "$ThisModulePath\Resources\$ResourceFile" -ErrorAction Stop
-                $errors = $null
-                $null = [System.Management.Automation.PSParser]::Tokenize($psfile, [ref]$errors)
-                $errors.Count | Should Be 0
-            }
-        }
-        # TODO - add tests to check for tests files
     }
 
-    Context "PowerShell $ThisModuleName Import Test" {
-        # Credit - borrowed with care from https://github.com/TheMattCollins0/MattTools/blob/master/Tests/ModuleImport.Tests.ps1 and modified as needed
-        It "Should import PowerShell $ThisModuleName successfully" {
-            Import-Module -Name $ThisModulePath -ErrorVariable ImportError
-            $ImportError | Should Be $null
+    #Both $File need to exist for assertion or the value goes null...IDK why
+    Context "[ $ThisModuleName ] Testing for valid PowerShell code" {
+
+        ForEach ($File in $ModuleFiles) {
+
+            #Region Discovery
+
+                $File = @{ File = $File }
+
+            #EndRegion Discovery
+
+                It "[ $ThisModuleName ] valid PowerShell code for: $($File.File.Name)" -TestCases $File {
+                    $File = @{ File = $File }
+                    $psFile = Get-Content -Path $($File.File.FullName) -ErrorAction Stop
+                    $errors = $null
+                    $null = [System.Management.Automation.PSParser]::Tokenize($psfile, [ref]$errors)
+                    $errors.Count | Should -Be 0
+                }
         }
     }
 }


### PR DESCRIPTION
Addresses issue #56 

Quite a bit to go over with this initial update so **ZERO rush** to get this in place but overall 99% of the changes are the addition of comment-based help to all wrapper functions with support for the `Get-Help <command name> -online` function.

Example:
`Get-Help Get-ITGlueUsers -online`

- This will take you to [https://api.itglue.com/developer/#accounts-users](https://api.itglue.com/developer/#accounts-users)

 I believe I have everything in a good initial state but with writing some much documentation it wouldn't surprise me if there are grammar or consistency issues between the wrappers. I have tested most of the functions after the modifications and I have not found any issues yet but I am only familiar with GET methods right now.

What are everyone's thoughts on the structure and or next steps?

- Is there a better way to relay\show JSON examples in the help comments?

**Unless otherwise defined all modifications are additions of comment-based help**

0. **Pester Tests**
- Updated to Pester 5
- General test improvements _(could use some more tweaks)_
- Added HelpComment.Tests to help validate help-based comments

1. **APIKey**
- Added cmdletbinding to all functions
- Fixed basic scriptAnalyzer warnings
- New Test-ITGlueAPIKey
  - Added because its helpful when needing to validate general functionality or when using RMM deployment tools

2. **BaseURI**
- Added cmdletbinding to all functions
- Fixed basic scriptAnalyzer warnings
	
3. **ModuleSettings**
- Added cmdletbinding to all functions
- Fixed basic scriptAnalyzer warnings
- New Remove-ITGlueModuleSettings
  - Nice to remove saved settings from systems when no longer needed
	
5. **ConfigurationInterfaces**
- Added cmdletbinding to New-ITGlueConfigurationInterfaces
	
6. **Configurations**
- Added cmdletbinding to New-ITGlueConfigurations

7. **ConfigurationStatues**
- Added cmdletbinding to New-ITGlueConfigurationStatuses
- Added cmdletbinding to Set-ITGlueConfigurationStatuses
	
8. **ConfigurationTypes**
  - Added cmdletbinding to New-ITGlueConfigurationTypes
  - Added cmdletbinding to Set-ITGlueConfigurationTypes
	
9. **Contacts**
- Added cmdletbinding to New-ITGlueContacts

10. **ContactTypes**
- Added cmdletbinding to New-ITGlueContactTypes
- Added cmdletbinding to Set-ITGlueContactTypes
	
11. **FlexibleAssetFields**
- Added cmdletbinding to New-ITGlueFlexibleAssetFields
- _Might need to add in mandatory parameters to Get-ITGlueFlexibleAssetFields (Can come later)_
	
12. **FlexibleAssetTypes**
- Added cmdletbinding to New-ITGlueFlexibleAssetTypes
- Added cmdletbinding to Set-ITGlueFlexibleAssetTypes
	
13. **FlexibleAssets**
- _Might need to add mandatory parameter's to Get-ITGlueFlexibleAssets (Can come later)_

14. **Locations**
- Added cmdletbinding to New-ITGlueLocations
- _Should the "Remove-ITGlueLocations" data param need an update paramSet?_
	
15. **Manufacturers**
- Added cmdletbinding to New-ITGlueManufacturers
- Added cmdletbinding to Set-ITGlueManufacturers
	
16. **Models**
- Added cmdletbinding to New-ITGlueModels
	
17. **Organizations**
- Added cmdletbinding to New-ITGlueOrganizations
	
18. **OrganizationStatuses**
- Added cmdletbinding to New-ITGlueOrganizationStatuses
- Added cmdletbinding to Set-ITGlueOrganizationStatuses
	
19. **OrganizationTypes**
- Added cmdletbinding to New-ITGlueOrganizationTypes
- Added cmdletbinding to Set-ITGlueOrganizationTypes
	
20. **PasswordCategories**
- Added cmdletbinding to New-ITGluePasswordCategories
- Added cmdletbinding to Set-ITGluePasswordCategories
	
21. **Passwords**
- Added cmdletbinding to New-ITGluePasswords

22. **Users**
- Added cmdletbinding to Set-ITGlueUsers