### PR TITLE
Moved all API calls to new internal functions

### DIFF
--- a/ITGlueAPI/ITGlueAPI.psd1
+++ b/ITGlueAPI/ITGlueAPI.psd1
@@ -18,7 +18,7 @@
     # -- MINOR version when you add functionality in a backwards-compatible manner, and
     # -- PATCH version when you make backwards-compatible bug fixes.
 
-    ModuleVersion = '2.2.0'
+    ModuleVersion = '2.1.0'
 
     # ID used to uniquely identify this module
     GUID = 'f969cff1-3120-4980-8c46-83f2d0bf2521'
@@ -72,6 +72,7 @@
     NestedModules = 'Internal/BaseURI.ps1',
                     'Internal/APIKey.ps1',
                     'Internal/ModuleSettings.ps1',
+                    'Internal/APICalls.ps1',
                     'Resources/Attachments.ps1',
                     'Resources/ConfigurationInterfaces.ps1',
                     'Resources/Configurations.ps1',

--- a/ITGlueAPI/Internal/APICalls.ps1
+++ b/ITGlueAPI/Internal/APICalls.ps1
@@ -1,0 +1,159 @@
+function New-ITGlue {
+    Param (
+        [Parameter(Mandatory = $true)]
+        [String]$resource_uri,
+        [Parameter(Mandatory = $true)]
+        [Hashtable]$data
+    )
+
+    $body = @{'data'= $data}
+    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
+
+    try {
+        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
+
+        $parameters = @{
+            "Method" = 'POST'
+            "Uri" = $ITGlue_Base_URI + $resource_uri
+            "Headers" = $ITGlue_Headers
+            "Body" = $body
+        }
+
+        $rest_output = Invoke-RestMethod @parameters -ErrorAction Stop
+    } catch {
+        Write-Error $_
+    } finally {
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
+    }
+
+    $data = @{}
+    $data = $rest_output
+    return $data
+}
+
+function Get-ITGlue {
+    Param (
+        [Parameter(Mandatory = $true)]
+        [String]$resource_uri,
+
+        [Hashtable]$filter_list = @{}
+    )
+
+    $filter = ""
+    foreach($key in $filter_list.keys) {
+        $filter += "$key=$($filter[$key])&"
+    }
+
+    $filter = $filter.trimEnd("&") # Remove trailing &.
+
+    if(-not [System.String]::IsNullOrEmpty($filter)) { # Skip if no filer was added.
+        $resource_uri = "{0}?{1}" -f $resource_uri, $filter
+    }
+
+    try {
+        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
+
+        $parameters = @{
+            "Method" = 'GET'
+            "Uri" = $ITGlue_Base_URI + $resource_uri
+            "Headers" = $ITGlue_Headers
+        }
+
+        $rest_output = Invoke-RestMethod @parameters -ErrorAction Stop
+    } catch {
+        Write-Error $_
+    } finally {
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
+    }
+
+    $data = @{}
+    $data = $rest_output
+    return $data
+}
+
+function Set-ITGlue {
+    Param (
+        [Parameter(Mandatory = $true)]
+        [String]$resource_uri,
+
+        [Parameter(Mandatory = $true)]
+        [Hashtable]$data,
+
+        [Hashtable]$filter_list = @{}
+    )
+
+    $body = @{}
+    if($filter_list.Count -gt 0)  { # Only run if filters are provided
+        foreach($key in $filter_list.keys) { # Loop all filters and add them to the body.
+            $body[$key] = $filter_list[$key]
+        }
+    }
+
+    $body['data'] = $data
+    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
+
+    try {
+        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
+
+        $parameters = @{
+            "Method" = 'PATCH'
+            "Uri" = $ITGlue_Base_URI + $resource_uri
+            "Headers" = $ITGlue_Headers
+            "Body" = $body
+        }
+
+        $rest_output = Invoke-RestMethod @parameters -ErrorAction Stop
+    } catch {
+        Write-Error $_
+    } finally {
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
+    }
+
+    $data = @{}
+    $data = $rest_output
+    return $data
+}
+
+function Remove-ITGlue {
+    Param (
+        [Parameter(Mandatory = $true)]
+        [String]$resource_uri,
+
+        [Parameter(Mandatory = $true)]
+        [Hashtable]$data,
+
+        [Hashtable]$filter_list = @{}
+    )
+
+    $body = @{}
+
+    if($filter_list.Count -gt 0)  { # Only run if filters are provided
+        foreach($key in $filter_list.keys) { # Loop all filters and add them to the body.
+            $body[$key] = $filter_list[$key]
+        }
+    }
+
+    $body['data'] = $data
+    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
+
+    try {
+        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
+
+        $parameters = @{
+            "Method" = 'DELETE'
+            "Uri" = $ITGlue_Base_URI + $resource_uri
+            "Headers" = $ITGlue_Headers
+            "Body" = $body
+        }
+
+        $rest_output = Invoke-RestMethod @parameters -ErrorAction Stop
+    } catch {
+        Write-Error $_
+    } finally {
+        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
+    }
+
+    $data = @{}
+    $data = $rest_output
+    return $data
+}

--- a/ITGlueAPI/Resources/Attachments.ps1
+++ b/ITGlueAPI/Resources/Attachments.ps1
@@ -15,25 +15,8 @@ function New-ITGlueAttachments {
 
     $resource_uri = ('/{0}/{1}/relationships/attachments' -f $resource_type, $resource_id)
 
-    $body = @{}
+    return New-ITGlue -resource_uri $resource_uri -data $data
 
-    $body += @{'data'= $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] $ITGlue_Headers.Remove('x-api-key') # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
 }
 
 function Set-ITGlueAttachments {
@@ -57,25 +40,7 @@ function Set-ITGlueAttachments {
 
     $resource_uri = ('/{0}/{1}/relationships/attachments/{2}' -f $resource_type, $resource_id, $id)
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] $ITGlue_Headers.Remove('x-api-key') # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Remove-ITGlueAttachments {
@@ -95,23 +60,5 @@ function Remove-ITGlueAttachments {
 
     $resource_uri = ('/{0}/{1}/relationships/attachments' -f $resource_type, $resource_id)
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'DELETE' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] $ITGlue_Headers.Remove('x-api-key') # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Remove-ITGlue -resource_uri $resource_uri -data $data
 }

--- a/ITGlueAPI/Resources/ConfigurationInterfaces.ps1
+++ b/ITGlueAPI/Resources/ConfigurationInterfaces.ps1
@@ -12,25 +12,7 @@ function New-ITGlueConfigurationInterfaces {
         $resource_uri = ('/configurations/{0}/relationships/configuration_interfaces' -f $conf_id)
     }
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Get-ITGlueConfigurationInterfaces {
@@ -71,39 +53,27 @@ function Get-ITGlueConfigurationInterfaces {
         }
     }
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if ($filter_ip_address) {
-            $body += @{'filter[ip_address]' = $filter_ip_address }
+            $filter_list['filter[ip_address]'] = $filter_ip_address
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
 
 function Set-ITGlueConfigurationInterfaces {
@@ -130,29 +100,13 @@ function Set-ITGlueConfigurationInterfaces {
         $resource_uri = ('/configurations/{0}/relationships/configuration_interfaces/{1}' -f $conf_id, $id)
     }
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'bulk_delete') {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
     }
 
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data -filter_list $filter_list
 }

--- a/ITGlueAPI/Resources/ConfigurationStatuses.ps1
+++ b/ITGlueAPI/Resources/ConfigurationStatuses.ps1
@@ -6,20 +6,7 @@ function New-ITGlueConfigurationStatuses {
 
     $resource_uri = '/configuration_statuses/'
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-    $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-        -body $body -ErrorAction Stop -ErrorVariable $web_error
-    [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Get-ITGlueConfigurationStatuses {
@@ -45,31 +32,24 @@ function Get-ITGlueConfigurationStatuses {
 
     $resource_uri = ('/configuration_statuses/{0}' -f $id)
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
-    $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-    $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-        -body $body -ErrorAction Stop -ErrorVariable $web_error
-    [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
 
 function Set-ITGlueConfigurationStatuses {
@@ -83,18 +63,5 @@ function Set-ITGlueConfigurationStatuses {
 
     $resource_uri = ('/configuration_statuses/{0}' -f $id)
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-    $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-        -body $body -ErrorAction Stop -ErrorVariable $web_error
-    [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data
 }

--- a/ITGlueAPI/Resources/ConfigurationTypes.ps1
+++ b/ITGlueAPI/Resources/ConfigurationTypes.ps1
@@ -6,25 +6,7 @@ function New-ITGlueConfigurationTypes {
 
     $resource_uri = '/configuration_types/'
 
-    $body = @{}
-
-    $body += @{'data'= $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Get-ITGlueConfigurationTypes {
@@ -50,36 +32,24 @@ function Get-ITGlueConfigurationTypes {
 
     $resource_uri = ('/configuration_types/{0}' -f $id)
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
 
 function Set-ITGlueConfigurationTypes {
@@ -93,23 +63,5 @@ function Set-ITGlueConfigurationTypes {
 
     $resource_uri = ('/configuration_types/{0}' -f $id)
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data
 }

--- a/ITGlueAPI/Resources/Configurations.ps1
+++ b/ITGlueAPI/Resources/Configurations.ps1
@@ -12,25 +12,7 @@ function New-ITGlueConfigurations {
         $resource_uri = ('/organizations/{0}/relationships/configurations' -f $organization_id)
     }
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Get-ITGlueConfigurations {
@@ -155,76 +137,64 @@ function Get-ITGlueConfigurations {
         $resource_uri = ('/configurations/{0}' -f $id)
     }
 
-    $body = @{}
+    $filter_list = @{}
 
     if (($PSCmdlet.ParameterSetName -eq 'index') -or `
         ($PSCmdlet.ParameterSetName -eq 'index_rmm') -or `
         ($PSCmdlet.ParameterSetName -eq 'index_psa') -or `
         ($PSCmdlet.ParameterSetName -eq 'index_rmm_psa')) {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($filter_organization_id) {
-            $body += @{'filter[organization_id]' = $filter_organization_id}
+            $filter_list['filter[organization_id]'] = $filter_organization_id
         }
         if ($filter_archived) {
-            $body += @{'filter[archived]' = $filter_archived}
+            $filter_list['filter[archived]'] = $filter_archived
         }
         if ($filter_configuration_type_id) {
-            $body += @{'filter[configuration_type_id]' = $filter_configuration_type_id}
+            $filter_list['filter[configuration_type_id]'] = $filter_configuration_type_id
         }
         if ($filter_configuration_status_id) {
-            $body += @{'filter[configuration_status_id]' = $filter_configuration_status_id}
+            $filter_list['filter[configuration_status_id]'] = $filter_configuration_status_id
         }
         if ($filter_contact_id) {
-            $body += @{'filter[contact_id]' = $filter_contact_id}
+            $filter_list['filter[contact_id]'] = $filter_contact_id
         }
         if ($filter_serial_number) {
-            $body += @{'filter[serial_number]' = $filter_serial_number}
+            $filter_list['filter[serial_number]'] = $filter_serial_number
         }
         if ($filter_rmm_integration_type) {
-            $body += @{'filter[rmm_integration_type]' = $filter_rmm_integration_type}
+            $filter_list['filter[rmm_integration_type]'] = $filter_rmm_integration_type
         }
         if ($filter_psa_integration_type) {
-            $body += @{'filter[psa_integration_type]' = $filter_psa_integration_type}
+            $filter_list['filter[psa_integration_type]'] = $filter_psa_integration_type
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
     if (($PSCmdlet.ParameterSetName -eq 'index_rmm') -or ($PSCmdlet.ParameterSetName -eq 'index_rmm_psa')) {
-        $body += @{'filter[rmm_id]' = $filter_rmm_id}
+        $filter_list['filter[rmm_id]'] = $filter_rmm_id
     }
     if (($PSCmdlet.ParameterSetName -eq 'index_psa') -or ($PSCmdlet.ParameterSetName -eq 'index_rmm_psa')) {
-        $body += @{'filter[psa_id]' = $filter_psa_id}
+        $filter_list['filter[psa_id]'] = $filter_psa_id
     }
 
     if($include) {
-        $body += @{'include' = $include}
+        $filter_list['include'] = $include
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers -body $body
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
 
 function Set-ITGlueConfigurations {
@@ -319,64 +289,48 @@ function Set-ITGlueConfigurations {
         $resource_uri = ('/organizations/{0}/relationships/configurations/{1}' -f $organization_id, $id)
     }
 
-    $body = @{}
+    $filter_list = @{}
 
     if (($PSCmdlet.ParameterSetName -eq 'bulk_update') -or `
         ($PSCmdlet.ParameterSetName -eq 'bulk_update_rmm') -or `
         ($PSCmdlet.ParameterSetName -eq 'bulk_update_psa') -or `
         ($PSCmdlet.ParameterSetName -eq 'bulk_update_rmm_psa')) {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($filter_organization_id) {
-            $body += @{'filter[organization_id]' = $filter_organization_id}
+            $filter_list['filter[organization_id]'] = $filter_organization_id
         }
         if ($filter_configuration_type_id) {
-            $body += @{'filter[configuration_type_id]' = $filter_configuration_type_id}
+            $filter_list['filter[configuration_type_id]'] = $filter_configuration_type_id
         }
         if ($filter_configuration_status_id) {
-            $body += @{'filter[configuration_status_id]' = $filter_configuration_status_id}
+            $filter_list['filter[configuration_status_id]'] = $filter_configuration_status_id
         }
         if ($filter_contact_id) {
-            $body += @{'filter[contact_id]' = $filter_contact_id}
+            $filter_list['filter[contact_id]'] = $filter_contact_id
         }
         if ($filter_serial_number) {
-            $body += @{'filter[serial_number]' = $filter_serial_number}
+            $filter_list['filter[serial_number]'] = $filter_serial_number
         }
         if ($filter_rmm_id) {
-            $body += @{'filter[rmm_id]' = $filter_rmm_id}
+            $filter_list['filter[rmm_id]'] = $filter_rmm_id
         }
         if ($filter_rmm_integration_type) {
-            $body += @{'filter[rmm_integration_type]' = $filter_rmm_integration_type}
+            $filter_list['filter[rmm_integration_type]'] = $filter_rmm_integration_type
         }
     }
     if (($PSCmdlet.ParameterSetName -eq 'bulk_update_rmm') -or ($PSCmdlet.ParameterSetName -eq 'bulk_update_rmm_psa')) {
-        $body += @{'filter[rmm_id]' = $filter_rmm_id}
+        $filter_list['filter[rmm_id]'] = $filter_rmm_id
     }
     if (($PSCmdlet.ParameterSetName -eq 'bulk_update_psa') -or ($PSCmdlet.ParameterSetName -eq 'bulk_update_rmm_psa')) {
-        $body += @{'filter[psa_id]' = $filter_psa_id}
+        $filter_list['filter[psa_id]'] = $filter_psa_id
     }
 
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data -filter_list $filter_list
 }
 
 function Remove-ITGlueConfigurations {
@@ -422,35 +376,35 @@ function Remove-ITGlueConfigurations {
 
     $resource_uri = '/configurations/'
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'bulk_delete') {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($filter_organization_id) {
-            $body += @{'filter[organization_id]' = $filter_organization_id}
+            $filter_list['filter[organization_id]'] = $filter_organization_id
         }
         if ($filter_configuration_type_id) {
-            $body += @{'filter[configuration_type_id]' = $filter_configuration_type_id}
+            $filter_list['filter[configuration_type_id]'] = $filter_configuration_type_id
         }
         if ($filter_configuration_status_id) {
-            $body += @{'filter[configuration_status_id]' = $filter_configuration_status_id}
+            $filter_list['filter[configuration_status_id]'] = $filter_configuration_status_id
         }
         if ($filter_contact_id) {
-            $body += @{'filter[contact_id]' = $filter_contact_id}
+            $filter_list['filter[contact_id]'] = $filter_contact_id
         }
         if ($filter_serial_number) {
-            $body += @{'filter[serial_number]' = $filter_serial_number}
+            $filter_list['filter[serial_number]'] = $filter_serial_number
         }
         if ($filter_rmm_id) {
-            $body += @{'filter[rmm_id]' = $filter_rmm_id}
+            $filter_list['filter[rmm_id]'] = $filter_rmm_id
         }
         if ($filter_rmm_integration_type) {
-            $body += @{'filter[rmm_integration_type]' = $filter_rmm_integration_type}
+            $filter_list['filter[rmm_integration_type]'] = $filter_rmm_integration_type
         }
     } elseif ($PSCmdlet.ParameterSetName -eq 'delete') {
         $data = @(
@@ -463,21 +417,5 @@ function Remove-ITGlueConfigurations {
         )
     }
 
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'DELETE' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Remove-ITGlue -resource_uri $resource_uri -data $data -filter_list $filter_list
 }

--- a/ITGlueAPI/Resources/ContactTypes.ps1
+++ b/ITGlueAPI/Resources/ContactTypes.ps1
@@ -6,25 +6,7 @@ function New-ITGlueContactTypes {
 
     $resource_uri = '/contact_types/'
 
-    $body = @{}
-
-    $body += @{'data'= $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Get-ITGlueContactTypes {
@@ -50,36 +32,24 @@ function Get-ITGlueContactTypes {
 
     $resource_uri = ('/contact_types/{0}' -f $id)
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
 
 function Set-ITGlueContactTypes {
@@ -93,23 +63,5 @@ function Set-ITGlueContactTypes {
 
     $resource_uri = ('/contact_types/{0}' -f $id)
 
-    $body = @{}
-
-    $body += @{'data'= $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data
 }

--- a/ITGlueAPI/Resources/Contacts.ps1
+++ b/ITGlueAPI/Resources/Contacts.ps1
@@ -12,25 +12,7 @@ function New-ITGlueContacts {
         $resource_uri = ('/organizations/{0}/relationships/contacts' -f $organization_id)
     }
 
-    $body = @{}
-
-    $body += @{'data'= $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Get-ITGlueContacts {
@@ -105,67 +87,55 @@ function Get-ITGlueContacts {
         $resource_uri = ('/organizations/{0}/relationships' -f $organization_id) + $resource_uri
     }
 
-    $body = @{}
+    $filter_list = @{}
 
     if (($PSCmdlet.ParameterSetName -eq 'index') -or ($PSCmdlet.ParameterSetName -eq 'index_psa')) {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if ($filter_first_name) {
-            $body += @{'filter[first_name]' = $filter_first_name}
+            $filter_list['filter[first_name]'] = $filter_first_name
         }
         if ($filter_last_name) {
-            $body += @{'filter[last_name]' = $filter_last_name}
+            $filter_list['filter[last_name]'] = $filter_last_name
         }
         if ($filter_title) {
-            $body += @{'filter[title]' = $filter_title}
+            $filter_list['filter[title]'] = $filter_title
         }
         if ($filter_contact_type_id) {
-            $body += @{'filter[contact_type_id]' = $filter_contact_type_id}
+            $filter_list['filter[contact_type_id]'] = $filter_contact_type_id
         }
         if ($filter_important -eq $true) {
-            $body += @{'filter[important]' = '1'}
+            $filter_list['filter[important]'] = '1'
         }
         elseif ($filter_important -eq $false) {
-            $body += @{'filter[important]' = '0'}
+            $filter_list['filter[important]'] = '0'
         }
         if ($filter_primary_email) {
-            $body += @{'filter[primary_email]' = $filter_primary_email}
+            $filter_list['filter[primary_email]'] = $filter_primary_email
         }
         if ($filter_psa_integration_type) {
-            $body += @{'filter[psa_integration_type]' = $filter_psa_integration_type}
+            $filter_list['filter[psa_integration_type]'] = $filter_psa_integration_type
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
     if ($PSCmdlet.ParameterSetName -eq 'index_psa') {
-        $body += @{'filter[psa_id]' = $filter_psa_id}
+        $filter_list['filter[psa_id]'] = $filter_psa_id
     }
 
     if($include) {
-        $body += @{'include' = $include}
+        $filter_list += @{'include' = $include}
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
 
 function Set-ITGlueContacts {
@@ -211,52 +181,36 @@ function Set-ITGlueContacts {
         $resource_uri = ('/organizations/{0}/relationships/contacts/{1}' -f $organization_id, $id)
     }
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'bulk_update') {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if ($filter_first_name) {
-            $body += @{'filter[first_name]' = $filter_first_name}
+            $filter_list['filter[first_name]'] = $filter_first_name
         }
         if ($filter_last_name) {
-            $body += @{'filter[last_name]' = $filter_last_name}
+            $filter_list['filter[last_name]'] = $filter_last_name
         }
         if ($filter_title) {
-            $body += @{'filter[title]' = $filter_title}
+            $filter_list['filter[title]'] = $filter_title
         }
         if ($filter_contact_type_id) {
-            $body += @{'filter[contact_type_id]' = $filter_contact_type_id}
+            $filter_list['filter[contact_type_id]'] = $filter_contact_type_id
         }
         if ($filter_important -eq $true) {
-            $body += @{'filter[important]' = '1'}
+            $filter_list['filter[important]'] = '1'
         }
         elseif ($filter_import -eq $false) {
-            $body += @{'filter[important]' = '0'}
+            $filter_list['filter[important]'] = '0'
         }
         if ($filter_primary_email) {
-            $body += @{'filter[primary_email]' = $filter_primary_email}
+            $filter_list['filter[primary_email]'] = $filter_primary_email
         }
     }
 
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data -filter_list $filter_list
 }
 
 function Remove-ITGlueContacts {
@@ -294,50 +248,34 @@ function Remove-ITGlueContacts {
         $resource_uri = ('/organizations/{0}/relationships/contacts/{1}' -f $organization_id, $id)
     }
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'bulk_destroy') {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if ($filter_first_name) {
-            $body += @{'filter[first_name]' = $filter_first_name}
+            $filter_list['filter[first_name]'] = $filter_first_name
         }
         if ($filter_last_name) {
-            $body += @{'filter[last_name]' = $filter_last_name}
+            $filter_list['filter[last_name]'] = $filter_last_name
         }
         if ($filter_title) {
-            $body += @{'filter[title]' = $filter_title}
+            $filter_list['filter[title]'] = $filter_title
         }
         if ($filter_contact_type_id) {
-            $body += @{'filter[contact_type_id]' = $filter_contact_type_id}
+            $filter_list['filter[contact_type_id]'] = $filter_contact_type_id
         }
         if ($filter_important -eq $true) {
-            $body += @{'filter[important]' = '1'}
+            $filter_list['filter[important]'] = '1'
         }
         elseif ($filter_important -eq $false) {
-            $body += @{'filter[important]' = '0'}
+            $filter_list['filter[important]'] = '0'
         }
         if ($filter_primary_email) {
-            $body += @{'filter[primary_email]' = $filter_primary_email}
+            $filter_list['filter[primary_email]'] = $filter_primary_email
         }
     }
 
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'DELETE' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Remove-ITGlue -resource_uri $resource_uri -data $data -filter_list $filter_list
 }

--- a/ITGlueAPI/Resources/Countries.ps1
+++ b/ITGlueAPI/Resources/Countries.ps1
@@ -24,35 +24,25 @@ function Get-ITGlueCountries {
 
     $resource_uri = ('/countries/{0}' -f $id)
 
+    $filter_list = @{}
+
     if ($PSCmdlet.ParameterSetName -eq "index") {
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($filter_iso) {
-            $body += @{'filter[iso]' = $filter_iso}
+            $filter_list['filter[iso]'] = $filter_iso
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{"page[number]" = $page_number}
+            $filter_list["page[number]"] = $page_number
         }
         if ($page_size) {
-            $body += @{"page[size]" = $page_size}
+            $filter_list["page[size]"] = $page_size
         }
     }
 
-    try {
-        $ITGlue_Headers.Add("x-api-key", (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method "GET" -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }

--- a/ITGlueAPI/Resources/Documents.ps1
+++ b/ITGlueAPI/Resources/Documents.ps1
@@ -19,23 +19,5 @@ function Set-ITGlueDocuments {
         $resource_uri = ('/organizations/{0}/relationships/documents/{1}' -f $organization_id, $id)
     }
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] $ITGlue_Headers.Remove('x-api-key') # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data
 }

--- a/ITGlueAPI/Resources/Domains.ps1
+++ b/ITGlueAPI/Resources/Domains.ps1
@@ -30,41 +30,29 @@ function Get-ITGlueDomains {
         $resource_uri = ('/organizations/{0}/relationships/domains' -f $organization_id)
     }
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if ($filter_organization_id) {
-            $body += @{'filter[organization_id]' = $filter_organization_id}
+            $filter_list['filter[organization_id]'] = $filter_organization_id
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
     if($include) {
-        $body += @{'include' = $include}
+        $filter_list['include'] = $include
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers -body $body
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] $ITGlue_Headers.Remove('x-api-key') # Quietly clean up scope so the API key doesn't persist
-    }
-
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }

--- a/ITGlueAPI/Resources/Expirations.ps1
+++ b/ITGlueAPI/Resources/Expirations.ps1
@@ -49,55 +49,43 @@ function Get-ITGlueExpirations {
         $resource_uri = ('/organizations/{0}/relationships' -f $organization_id) + $resource_uri
     }
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if ($filter_resource_id) {
-            $body += @{'filter[resource_id]' = $filter_resource_id}
+            $filter_list['filter[resource_id]'] = $filter_resource_id
         }
         if ($filter_resource_name) {
-            $body += @{'filter[resource_name]' = $filter_resource_name}
+            $filter_list['filter[resource_name]'] = $filter_resource_name
         }
         if ($filter_resource_type_name) {
-            $body += @{'filter[resource_type_name]' = $filter_resource_type_name}
+            $filter_list['filter[resource_type_name]'] = $filter_resource_type_name
         }
         if ($filter_description) {
-            $body += @{'filter[description]' = $filter_description}
+            $filter_list['filter[description]'] = $filter_description
         }
         if ($filter_expiration_date) {
-            $body += @{'filter[expiration_date]' = $filter_expiration_date}
+            $filter_list['filter[expiration_date]'] = $filter_expiration_date
         }
         if ($filter_organization_id) {
-            $body += @{'filter[organization_id]' = $filter_organization_id}
+            $filter_list['filter[organization_id]'] = $filter_organization_id
         }
         if ($filter_range) {
-            $body += @{'filter[range]' = $filter_range}
+            $filter_list['filter[range]'] = $filter_range
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] $ITGlue_Headers.Remove('x-api-key') # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }

--- a/ITGlueAPI/Resources/FlexibleAssetFields.ps1
+++ b/ITGlueAPI/Resources/FlexibleAssetFields.ps1
@@ -12,25 +12,7 @@ function New-ITGlueFlexibleAssetFields {
         $resource_uri = ('/flexible_asset_types/{0}/relationships/flexible_asset_fields' -f $flexible_asset_type_id)
     }
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Get-ITGlueFlexibleAssetFields {
@@ -73,29 +55,29 @@ function Get-ITGlueFlexibleAssetFields {
         $resource_uri = ('/flexible_asset_types/{0}/relationships/flexible_asset_fields/{1}' -f $flexible_asset_type_id, $id)
     }
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($filter_icon) {
-            $body += @{'filter[icon]' = $filter_icon}
+            $filter_list['filter[icon]'] = $filter_icon
         }
         if ($null -ne $filter_enabled) {
-            $body += @{'filter[enabled]' = $filter_enabled}
+            $filter_list['filter[enabled]'] = $filter_enabled
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
     elseif ($null -eq $flexible_asset_type_id) {
@@ -103,19 +85,7 @@ function Get-ITGlueFlexibleAssetFields {
         $resource_uri = ('/flexible_asset_fields/{0}' -f $id)
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
 
 function Set-ITGlueFlexibleAssetFields {
@@ -142,31 +112,15 @@ function Set-ITGlueFlexibleAssetFields {
         $resource_uri = ('/flexible_asset_types/{0}/relationships/flexible_asset_fields/{1}' -f $flexible_asset_type_id, $id)
     }
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'bulk_update') {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
     }
 
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data -filter_list $filter_list
 }
 
 function Remove-ITGlueFlexibleAssetFields {
@@ -185,19 +139,6 @@ function Remove-ITGlueFlexibleAssetFields {
     }
 
     if ($pscmdlet.ShouldProcess($id)) {
-
-        try {
-            $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-            $rest_output = Invoke-RestMethod -method 'DELETE' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-                -ErrorAction Stop -ErrorVariable $web_error
-        } catch {
-            Write-Error $_
-        } finally {
-            [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-        }
-
-        $data = @{}
-        $data = $rest_output
-        return $data
+        return Remove-ITGlue -resource_uri $resource_uri -data $data
     }
 }

--- a/ITGlueAPI/Resources/FlexibleAssetTypes.ps1
+++ b/ITGlueAPI/Resources/FlexibleAssetTypes.ps1
@@ -6,25 +6,7 @@ function New-ITGlueFlexibleAssetTypes {
 
     $resource_uri = '/flexible_asset_types/'
 
-    $body = @{}
-
-    $body += @{'data'= $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 function Get-ITGlueFlexibleAssetTypes {
     [CmdletBinding(DefaultParameterSetName = 'index')]
@@ -58,50 +40,38 @@ function Get-ITGlueFlexibleAssetTypes {
 
     $resource_uri = ('/flexible_asset_types/{0}' -f $id)
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($filter_icon) {
-            $body += @{'filter[icon]' = $filter_icon}
+            $filter_list['filter[icon]'] = $filter_icon
         }
         if ($filter_enabled -eq $true) {
             # PS $true returns "True" in string form (uppercase) and ITG's API is case-sensitive, so being explicit
-            $body += @{'filter[enabled]' = "1"}
+            $filter_list['filter[enabled]'] = "1"
         }
         elseif ($filter_enabled -eq $false) {
-            $body += @{'filter[enabled]' = "0"}
+            $filter_list['filter[enabled]'] = "0"
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
     if($include) {
-        $body += @{'include' = $include}
+        $filter_list['include'] = $include
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
 
 function Set-ITGlueFlexibleAssetTypes {
@@ -115,23 +85,5 @@ function Set-ITGlueFlexibleAssetTypes {
 
     $resource_uri = ('/flexible_asset_types/{0}' -f $id)
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data
 }

--- a/ITGlueAPI/Resources/FlexibleAssets.ps1
+++ b/ITGlueAPI/Resources/FlexibleAssets.ps1
@@ -15,25 +15,7 @@ function New-ITGlueFlexibleAssets {
         $resource_uri = '/organizations/{0}/relationships/flexible_assets' -f $organization_id
     }
 
-    $body = @{}
-
-    $body += @{'data'= $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Get-ITGlueFlexibleAssets {
@@ -69,46 +51,34 @@ function Get-ITGlueFlexibleAssets {
 
     $resource_uri = ('/flexible_assets/{0}' -f $id)
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_flexible_asset_type_id) {
-            $body += @{'filter[flexible_asset_type_id]' = $filter_flexible_asset_type_id}
+            $filter_list['filter[flexible_asset_type_id]'] = $filter_flexible_asset_type_id
         }
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($filter_organization_id) {
-            $body += @{'filter[organization_id]' = $filter_organization_id}
+            $filter_list['filter[organization_id]'] = $filter_organization_id
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
     if ($include) {
-        $body += @{'include' = $include}
+        $filter_list['include'] = $include
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        $ITGlue_Headers.Remove('x-api-key') >$null # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
 
 function Set-ITGlueFlexibleAssets {
@@ -125,25 +95,7 @@ function Set-ITGlueFlexibleAssets {
 
     $resource_uri = ('/flexible_assets/{0}' -f $id)
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Remove-ITGlueFlexibleAssets {
@@ -156,19 +108,6 @@ function Remove-ITGlueFlexibleAssets {
     $resource_uri = ('/flexible_assets/{0}' -f $id)
 
     if ($pscmdlet.ShouldProcess($id)) {
-
-        try {
-            $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-            $rest_output = Invoke-RestMethod -method 'DELETE' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-                -ErrorAction Stop -ErrorVariable $web_error
-        } catch {
-            Write-Error $_
-        } finally {
-            [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-        }
-
-        $data = @{}
-        $data = $rest_output
-        return $data
+        return Remove-ITGlue -resource_uri $resource_uri -data $data
     }
 }

--- a/ITGlueAPI/Resources/Groups.ps1
+++ b/ITGlueAPI/Resources/Groups.ps1
@@ -21,32 +21,22 @@ function Get-ITGlueGroups {
 
     $resource_uri = ('/groups/{0}' -f $id)
 
+    $filter_list = @{}
+
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }

--- a/ITGlueAPI/Resources/Locations.ps1
+++ b/ITGlueAPI/Resources/Locations.ps1
@@ -9,25 +9,7 @@ function New-ITGlueLocations {
 
     $resource_uri = ('/organizations/{0}/relationships/locations/' -f $org_id)
 
-    $body = @{}
-
-    $body += @{'data'= $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 function Get-ITGlueLocations {
     [CmdletBinding(DefaultParameterSetName = 'index')]
@@ -93,58 +75,47 @@ function Get-ITGlueLocations {
         $resource_uri = ('/organizations/{0}/relationships' -f $org_id) + $resource_uri
     }
 
-    $body = @{}
+    $filter_list = @{}
 
     if (($PSCmdlet.ParameterSetName -eq 'index') -or ($PSCmdlet.ParameterSetName -eq 'index_psa')) {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($filter_city) {
-            $body += @{'filter[city]' = $filter_city}
+            $filter_list['filter[city]'] = $filter_city
         }
         if ($filter_region_id) {
-            $body += @{'filter[region_id]' = $filter_region_id}
+            $filter_list['filter[region_id]'] = $filter_region_id
         }
         if ($filter_country_id) {
-            $body += @{'filter[country_id]' = $filter_country_id}
+            $filter_list['filter[country_id]'] = $filter_country_id
         }
         if ($filter_psa_integration_type) {
-            $body += @{'filter[psa_integration_type]' = $filter_psa_integration_type}
+            $filter_list['filter[psa_integration_type]'] = $filter_psa_integration_type
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
     if ($PSCmdlet.ParameterSetName -eq 'index_psa') {
-        $body += @{'filter[psa_id]' = $filter_psa_id}
+        $filter_list['filter[psa_id]'] = $filter_psa_id
     }
 
     if($include) {
-        $body += @{'include' = $include}
+        $filter_list['include'] = $include
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
 
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
 
 function Set-ITGlueLocations {
@@ -183,43 +154,27 @@ function Set-ITGlueLocations {
         $resource_uri = ('organizations/{0}/relationships/locations/{1}' -f $org_id, $id)
     }
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'bulk_update') {
         if($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if($filter_city) {
-            $body += @{'filter[city]' = $filter_city}
+            $filter_list['filter[city]'] = $filter_city
         }
         if($filter_region_id) {
-            $body += @{'filter[region_id]' = $filter_region_id}
+            $filter_list['filter[region_id]'] = $filter_region_id
         }
         if($filter_country_id) {
-            $body += @{'filter[country_id]' = $filter_country_id}
+            $filter_list['filter[country_id]'] = $filter_country_id
         }
     }
 
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data -filter_list $filter_list
 }
 
 function Remove-ITGlueLocations {
@@ -248,41 +203,25 @@ function Remove-ITGlueLocations {
 
     $resource_uri = ('/locations/')
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'bulk_destroy') {
         if($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if($filter_city) {
-            $body += @{'filter[city]' = $filter_city}
+            $filter_list['filter[city]'] = $filter_city
         }
         if($filter_region_id) {
-            $body += @{'filter[region_id]' = $filter_region_id}
+            $filter_list['filter[region_id]'] = $filter_region_id
         }
         if($filter_country_id) {
-            $body += @{'filter[country_id]' = $filter_country_id}
+            $filter_list['filter[country_id]'] = $filter_country_id
         }
     }
 
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'DELETE' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Remove-ITGlue -resource_uri $resource_uri -data $data -filter_list $filter_list
 }

--- a/ITGlueAPI/Resources/Logs.ps1
+++ b/ITGlueAPI/Resources/Logs.ps1
@@ -78,29 +78,19 @@ function Get-ITGlueLogs {
 
         $resource_uri = '/logs'
 
+        $filter_list = @{}
+
         if ($PSCmdlet.ParameterSetName -eq 'index') {
             if ($sort) {
-                $body += @{'sort' = $sort}
+                $filter_list['sort'] = $sort
             }
             if ($page_number) {
-                $body += @{'page[number]' = $page_number}
+                $filter_list['page[number]'] = $page_number
             }
             if ($page_size) {
-                $body += @{'page[size]' = $page_size}
+                $filter_list['page[size]'] = $page_size
             }
         }
 
-        try {
-            $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-            $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-                -body $body -ErrorAction Stop -ErrorVariable web_error
-        } catch {
-            Write-Error $_
-        } finally {
-            [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-        }
-
-        $data = @{}
-        $data = $rest_output
-        return $data
+        return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
     }

--- a/ITGlueAPI/Resources/Manufacturers.ps1
+++ b/ITGlueAPI/Resources/Manufacturers.ps1
@@ -6,25 +6,7 @@ function New-ITGlueManufacturers {
 
     $resource_uri = '/manufacturers/'
 
-    $body = @{}
-
-    $body += @{'data'= $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Get-ITGlueManufacturers {
@@ -50,36 +32,24 @@ function Get-ITGlueManufacturers {
 
     $resource_uri = ('/manufacturers/{0}' -f $id)
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
 
 function Set-ITGlueManufacturers {
@@ -93,23 +63,5 @@ function Set-ITGlueManufacturers {
 
     $resource_uri = ('/manufacturers/{0}' -f $id)
 
-    $body = @{}
-
-    $body += @{'data'= $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data
 }

--- a/ITGlueAPI/Resources/Models.ps1
+++ b/ITGlueAPI/Resources/Models.ps1
@@ -12,25 +12,7 @@ function New-ITGlueModels {
         $resource_uri = ('/manufacturers/{0}/relationships/models' -f $manufacturer_id)
     }
 
-    $body = @{}
-
-    $body += @{'data'= $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Get-ITGlueModels {
@@ -63,36 +45,24 @@ function Get-ITGlueModels {
         $resource_uri = ('/manufacturers/{0}/relationships' -f $manufacturer_id) + $resource_uri
     }
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
 
 function Set-ITGlueModels {
@@ -119,29 +89,13 @@ function Set-ITGlueModels {
         $resource_uri = ('/manufacturers/{0}/relationships/models/{1}' -f $manufacturer_id, $id)
     }
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'bulk_update') {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
     }
 
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data -filter_list $filter_list
 }

--- a/ITGlueAPI/Resources/OperatingSystems.ps1
+++ b/ITGlueAPI/Resources/OperatingSystems.ps1
@@ -21,34 +21,22 @@ function Get-ITGlueOperatingSystems {
 
     $resource_uri = ('/operating_systems/{0}' -f $id)
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }

--- a/ITGlueAPI/Resources/OrganizationStatuses.ps1
+++ b/ITGlueAPI/Resources/OrganizationStatuses.ps1
@@ -6,25 +6,7 @@ function New-ITGlueOrganizationStatuses {
 
     $resource_uri = '/organization_statuses/'
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Get-ITGlueOrganizationStatuses {
@@ -50,36 +32,24 @@ function Get-ITGlueOrganizationStatuses {
 
     $resource_uri = ('/organization_statuses/{0}' -f $id)
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
 
 function Set-ITGlueOrganizationStatuses {
@@ -93,23 +63,5 @@ function Set-ITGlueOrganizationStatuses {
 
     $resource_uri = ('/organization_statuses/{0}' -f $id)
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data
 }

--- a/ITGlueAPI/Resources/OrganizationTypes.ps1
+++ b/ITGlueAPI/Resources/OrganizationTypes.ps1
@@ -6,25 +6,7 @@ function New-ITGlueOrganizationTypes {
 
     $resource_uri = '/organization_types/'
 
-    $body = @{}
-
-    $body = @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Get-ITGlueOrganizationTypes {
@@ -50,38 +32,26 @@ function Get-ITGlueOrganizationTypes {
 
     $resource_uri = ('/organization_types/{0}' -f $id)
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
+
 function Set-ITGlueOrganizationTypes {
     Param (
         [Parameter(Mandatory = $true)]
@@ -93,23 +63,5 @@ function Set-ITGlueOrganizationTypes {
 
     $resource_uri = ('/organization_types/{0}' -f $id)
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data
 }

--- a/ITGlueAPI/Resources/Organizations.ps1
+++ b/ITGlueAPI/Resources/Organizations.ps1
@@ -6,25 +6,7 @@ function New-ITGlueOrganizations {
 
     $resource_uri = '/organizations/'
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Get-ITGlueOrganizations {
@@ -89,75 +71,63 @@ function Get-ITGlueOrganizations {
 
     $resource_uri = ('/organizations/{0}' -f $id)
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($filter_organization_type_id) {
-            $body += @{'filter[organization_type_id]' = $filter_organization_type_id}
+            $filter_list['filter[organization_type_id]'] = $filter_organization_type_id
         }
         if ($filter_organization_status_id) {
-            $body += @{'filter[organization_status_id]' = $filter_organization_status_id}
+            $filter_list['filter[organization_status_id]'] = $filter_organization_status_id
         }
         if ($filter_created_at) {
-            $body += @{'filter[created_at]' = $filter_created_at}
+            $filter_list['filter[created_at]'] = $filter_created_at
         }
         if ($filter_updated_at) {
-            $body += @{'filter[updated_at]' = $filter_updated_at}
+            $filter_list['filter[updated_at]'] = $filter_updated_at
         }
         if ($filter_my_glue_account_id) {
-            $body += @{'filter[my_glue_account_id]' = $filter_my_glue_account_id}
+            $filter_list['filter[my_glue_account_id]'] = $filter_my_glue_account_id
         }
         if ($filter_group_id) {
-            $body += @{'filter[group_id]' = $filter_group_id}
+            $filter_list['filter[group_id]'] = $filter_group_id
         }
         if ($filter_exclude_id) {
-            $body += @{'filter[exclude][id]' = $filter_exclude_id}
+            $filter_list['filter[exclude][id]'] = $filter_exclude_id
         }
         if ($filter_exclude_name) {
-            $body += @{'filter[exclude][name]' = $filter_exclude_name}
+            $filter_list['filter[exclude][name]'] = $filter_exclude_name
         }
         if ($filter_exclude_organization_type_id) {
-            $body += @{'filter[exclude][organization_type_id]' = $filter_exclude_organization_type_id}
+            $filter_list['filter[exclude][organization_type_id]'] = $filter_exclude_organization_type_id
         }
         if ($filter_exclude_organization_type_id) {
-            $body += @{'filter[exclude][organization_status_id]' = $filter_exclude_organization_status_id}
+            $filter_list['filter[exclude][organization_status_id]'] = $filter_exclude_organization_status_id
         }
         if ($filter_range) {
-            $body += @{'filter[range]' = $filter_range}
+            $filter_list['filter[range]'] = $filter_range
         }
         if ($filter_range_my_glue_account_id) {
-            $body += @{'filter[range][my_glue_account_id]' = $filter_range_my_glue_account_id}
+            $filter_list['filter[range][my_glue_account_id]'] = $filter_range_my_glue_account_id
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
 
 function Set-ITGlueOrganizations {
@@ -208,61 +178,45 @@ function Set-ITGlueOrganizations {
 
     $resource_uri = ('/organizations/{0}' -f $id)
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'bulk_update') {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if($filter_organization_type_id) {
-            $body += @{'filter[organization_type_id]' = $filter_organization_type_id}
+            $filter_list['filter[organization_type_id]'] = $filter_organization_type_id
         }
         if($filter_organization_status_id) {
-            $body += @{'filter[organization_status_id]' = $filter_organization_status_id}
+            $filter_list['filter[organization_status_id]'] = $filter_organization_status_id
         }
         if($filter_created_at) {
-            $body += @{'filter[created_at]' = $filter_created_at}
+            $filter_list['filter[created_at]'] = $filter_created_at
         }
         if($filter_updated_at) {
-            $body += @{'filter[updated_at]' = $filter_updated_at}
+            $filter_list['filter[updated_at]'] = $filter_updated_at
         }
         if($filter_my_glue_account_id) {
-            $body += @{'filter[my_glue_account_id]' = $filter_my_glue_account_id}
+            $filter_list['filter[my_glue_account_id]'] = $filter_my_glue_account_id
         }
         if($filter_exclude_id) {
-            $body += @{'filter[exclude][id]' = $filter_exclude_id}
+            $filter_list['filter[exclude][id]'] = $filter_exclude_id
         }
         if($filter_exclude_name) {
-            $body += @{'filter[exclude][name]' = $filter_exclude_name}
+            $filter_list['filter[exclude][name]'] = $filter_exclude_name
         }
         if($filter_exclude_organization_type_id) {
-            $body += @{'filter[exclude][organization_type_id]' = $filter_exclude_organization_type_id}
+            $filter_list['filter[exclude][organization_type_id]'] = $filter_exclude_organization_type_id
         }
         if($filter_exclude_organization_status_id) {
-            $body += @{'filter[exclude][organization_status_id]' = $filter_exclude_organization_status_id}
+            $filter_list['filter[exclude][organization_status_id]'] = $filter_exclude_organization_status_id
         }
     }
 
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data -filter_list $filter_list
 }
 
 function Remove-ITGlueOrganizations {
@@ -309,59 +263,43 @@ function Remove-ITGlueOrganizations {
 
     $resource_uri = ('/organizations/{0}' -f $id)
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'bulk_destroy') {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if($filter_organization_type_id) {
-            $body += @{'filter[organization_type_id]' = $filter_organization_type_id}
+            $filter_list['filter[organization_type_id]'] = $filter_organization_type_id
         }
         if($filter_organization_status_id) {
-            $body += @{'filter[organization_status_id]' = $filter_organization_status_id}
+            $filter_list['filter[organization_status_id]'] = $filter_organization_status_id
         }
         if($filter_created_at) {
-            $body += @{'filter[created_at]' = $filter_created_at}
+            $filter_list['filter[created_at]'] = $filter_created_at
         }
         if($filter_updated_at) {
-            $body += @{'filter[updated_at]' = $filter_updated_at}
+            $filter_list['filter[updated_at]'] = $filter_updated_at
         }
         if($filter_my_glue_account_id) {
-            $body += @{'filter[my_glue_account_id]' = $filter_my_glue_account_id}
+            $filter_list['filter[my_glue_account_id]'] = $filter_my_glue_account_id
         }
         if($filter_exclude_id) {
-            $body += @{'filter[exclude][id]' = $filter_exclude_id}
+            $filter_list['filter[exclude][id]'] = $filter_exclude_id
         }
         if($filter_exclude_name) {
-            $body += @{'filter[exclude][name]' = $filter_exclude_name}
+            $filter_list['filter[exclude][name]'] = $filter_exclude_name
         }
         if($filter_exclude_organization_type_id) {
-            $body += @{'filter[exclude][organization_type_id]' = $filter_exclude_organization_type_id}
+            $filter_list['filter[exclude][organization_type_id]'] = $filter_exclude_organization_type_id
         }
         if($filter_exclude_organization_status_id) {
-            $body += @{'filter[exclude][organization_status_id]' = $filter_exclude_organization_status_id}
+            $filter_list['filter[exclude][organization_status_id]'] = $filter_exclude_organization_status_id
         }
     }
 
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'DELETE' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Remove-ITGlue -resource_uri $resource_uri -data $data -filter_list $filter_list
 }

--- a/ITGlueAPI/Resources/PasswordCategories.ps1
+++ b/ITGlueAPI/Resources/PasswordCategories.ps1
@@ -1,4 +1,4 @@
-function New-ITGluePasswordCategories{
+function New-ITGluePasswordCategories {
     Param (
         [Parameter(Mandatory = $true)]
         $data
@@ -6,25 +6,7 @@ function New-ITGluePasswordCategories{
 
     $resource_uri = '/password_categories/'
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Get-ITGluePasswordCategories {
@@ -50,36 +32,24 @@ function Get-ITGluePasswordCategories {
 
     $resource_uri = ('/password_categories/{0}' -f $id)
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
 
 function Set-ITGluePasswordCategories {
@@ -93,23 +63,5 @@ function Set-ITGluePasswordCategories {
 
     $resource_uri = ('/password_categories/{0}' -f $id)
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data
 }

--- a/ITGlueAPI/Resources/Passwords.ps1
+++ b/ITGlueAPI/Resources/Passwords.ps1
@@ -18,25 +18,7 @@ function New-ITGluePasswords {
         $resource_uri = $resource_uri + ('?show_password=false') # using $False in PS results in 'False' (uppercase false), so explicitly writing out 'false' is needed
     }
 
-    $body = @{}
-
-    $body += @{'data'= $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Get-ITGluePasswords {
@@ -95,29 +77,38 @@ function Get-ITGluePasswords {
         $resource_uri = ('/organizations/{0}/relationships/passwords/{1}' -f $organization_id, $id)
     }
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'index') {
-        if ($filter_id) {$body += @{'filter[id]' = $filter_id}
+        if ($filter_id) {
+            $filter_list['filter[id]'] = $filter_id
         }
-        if ($filter_name) {$body += @{'filter[name]' = $filter_name}
+        if ($filter_name) {
+            $filter_list['filter[name]'] = $filter_name
         }
-        if ($filter_archived) {$body += @{'filter[archived]' = $filter_archived}
+        if ($filter_archived) {
+            $filter_list['filter[archived]'] = $filter_archived
         }
-        if ($filter_organization_id) {$body += @{'filter[organization_id]' = $filter_organization_id}
+        if ($filter_organization_id) {
+            $filter_list['filter[organization_id]'] = $filter_organization_id
         }
-        if ($filter_password_category_id) {$body += @{'filter[password_category_id]' = $filter_password_category_id}
+        if ($filter_password_category_id) {
+            $filter_list['filter[password_category_id]'] = $filter_password_category_id
         }
-        if ($filter_url) {$body += @{'filter[url]' = $filter_url}
+        if ($filter_url) {
+            $filter_list['filter[url]'] = $filter_url
         }
-        if ($filter_cached_resource_name) {$body += @{'filter[cached_resource_name]' = $filter_cached_resource_name}
+        if ($filter_cached_resource_name) {
+            $filter_list['filter[cached_resource_name]'] = $filter_cached_resource_name
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
-        if ($page_number) {$body += @{'page[number]' = $page_number}
+        if ($page_number) {
+            $filter_list['page[number]'] = $page_number
         }
-        if ($page_size) {$body += @{'page[size]' = $page_size}
+        if ($page_size) {
+            $filter_list['page[size]'] = $page_size
         }
     }
     elseif ($null -eq $organization_id) {
@@ -126,26 +117,14 @@ function Get-ITGluePasswords {
     }
 
     if (!$show_password) {
-        $resource_uri = $resource_uri + ('?show_password=false') # using $False in PS results in 'False' (uppercase false), so explicitly writing out 'false' is needed
+        $filter_list['show_password'] = 'false' # using $False in PS results in 'False' (uppercase false), so explicitly writing out 'false' is needed
     }
 
     if($include) {
-        $body += @{'include' = $include}
+        $filter_list['include'] = $include
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
 
 function Set-ITGluePasswords {
@@ -176,25 +155,7 @@ function Set-ITGluePasswords {
         $resource_uri = $resource_uri + ('?show_password=true') # using $True in PS results in 'True' (uppercase T), so explicitly writing out 'true' is needed
     }
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Remove-ITGluePasswords {
@@ -227,44 +188,28 @@ function Remove-ITGluePasswords {
 
     $resource_uri = ('/passwords/{0}' -f $id)
 
-    $body = @{}
+    $filter_list = @{}
 
     if ($PSCmdlet.ParameterSetName -eq 'bulk_destroy') {
         if ($filter_id) {
-            $body += @{'filter[id]' = $filter_id}
+            $filter_list['filter[id]'] = $filter_id
         }
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($filter_organization_id) {
-            $body += @{'filter[organization_id]' = $filter_organization_id}
+            $filter_list['filter[organization_id]'] = $filter_organization_id
         }
         if ($filter_password_category_id) {
-            $body += @{'filter[password_category_id]' = $filter_password_category_id}
+            $filter_list['filter[password_category_id]'] = $filter_password_category_id
         }
         if ($filter_url) {
-            $body += @{'filter[url]' = $filter_url}
+            $filter_list['filter[url]'] = $filter_url
         }
         if ($filter_cached_resource_name) {
-            $body += @{'filter[cached_resource_name]' = $filter_cached_resource_name}
+            $filter_list['filter[cached_resource_name]'] = $filter_cached_resource_name
         }
-
-        $body += @{'data' = $data}
-
-        $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'DELETE' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Remove-ITGlue -resource_uri $resource_uri -data $data -filter_list $filter_list
 }

--- a/ITGlueAPI/Resources/Platforms.ps1
+++ b/ITGlueAPI/Resources/Platforms.ps1
@@ -21,32 +21,22 @@ function Get-ITGluePlatforms {
 
     $resource_uri = ('/platforms/{0}' -f $id)
 
+    $filter_list = @{}
+
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }

--- a/ITGlueAPI/Resources/Regions.ps1
+++ b/ITGlueAPI/Resources/Regions.ps1
@@ -34,38 +34,28 @@ function Get-ITGlueRegions {
         $resource_uri = ('/countries/{0}/relationships' -f $country_id) + $resource_uri
     }
 
+    $filter_list = @{}
+
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($filter_iso) {
-            $body += @{'filter[iso]' = $filter_iso}
+            $filter_list['filter[iso]'] = $filter_iso
         }
         if ($filter_country_id) {
-            $body += @{'filter[country_id]' = $filter_country_id}
+            $filter_list['filter[country_id]'] = $filter_country_id
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }

--- a/ITGlueAPI/Resources/RelatedItems.ps1
+++ b/ITGlueAPI/Resources/RelatedItems.ps1
@@ -15,25 +15,7 @@ function New-ITGlueRelatedItems {
 
     $resource_uri = ('/{0}/{1}/relationships/related_items' -f $resource_type, $resource_id)
 
-    $body = @{}
-
-    $body += @{'data'= $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'POST' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] $ITGlue_Headers.Remove('x-api-key') # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return New-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Set-ITGlueRelatedItems {
@@ -57,25 +39,7 @@ function Set-ITGlueRelatedItems {
 
     $resource_uri = ('/{0}/{1}/relationships/related_items/{2}' -f $resource_type, $resource_id, $id)
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] $ITGlue_Headers.Remove('x-api-key') # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data
 }
 
 function Remove-ITGlueRelatedItems {
@@ -95,23 +59,5 @@ function Remove-ITGlueRelatedItems {
 
     $resource_uri = ('/{0}/{1}/relationships/related_items' -f $resource_type, $resource_id)
 
-    $body = @{}
-
-    $body += @{'data' = $data}
-
-    $body = ConvertTo-Json -InputObject $body -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'DELETE' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] $ITGlue_Headers.Remove('x-api-key') # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Remove-ITGlue -resource_uri $resource_uri -data $data
 }

--- a/ITGlueAPI/Resources/UserMetrics.ps1
+++ b/ITGlueAPI/Resources/UserMetrics.ps1
@@ -27,41 +27,31 @@ function Get-ITGlueUserMetrics {
 
     $resource_uri = '/user_metrics'
 
+    $filter_list = @{}
+
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_user_id) {
-            $body += @{'filter[user_id]' = $filter_user_id}
+            $filter_list['filter[user_id]'] = $filter_user_id
         }
         if ($filter_organization_id) {
-            $body += @{'filter[organization_id]' = $filter_organization_id}
+            $filter_list['filter[organization_id]'] = $filter_organization_id
         }
         if ($filter_resource_type) {
-            $body += @{'filter[resource_type]' = $filter_resource_type}
+            $filter_list['filter[resource_type]'] = $filter_resource_type
         }
         if ($filter_date) {
-            $body += @{'filter[date]' = $filter_date}
+            $filter_list['filter[date]'] = $filter_date
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method GET -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }

--- a/ITGlueAPI/Resources/Users.ps1
+++ b/ITGlueAPI/Resources/Users.ps1
@@ -28,40 +28,30 @@ function Get-ITGlueUsers {
 
     $resource_uri = ('/users/{0}' -f $id)
 
+    $filter_list = @{}
+
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_name) {
-            $body += @{'filter[name]' = $filter_name}
+            $filter_list['filter[name]'] = $filter_name
         }
         if ($filter_email) {
-            $body += @{'filter[email]' = $filter_email}
+            $filter_list['filter[email]'] = $filter_email
         }
         if ($filter_role_name) {
-            $body += @{'filter[role_name]' = $filter_role_name}
+            $filter_list['filter[role_name]'] = $filter_role_name
         }
         if ($sort) {
-            $body += @{'sort' = $sort}
+            $filter_list['sort'] = $sort
         }
         if ($page_number) {
-            $body += @{'page[number]' = $page_number}
+            $filter_list['page[number]'] = $page_number
         }
         if ($page_size) {
-            $body += @{'page[size]' = $page_size}
+            $filter_list['page[size]'] = $page_size
         }
     }
 
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'GET' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Get-ITGlue -resource_uri $resource_uri -filter_list $filter_list
 }
 
 function Set-ITGlueUsers {
@@ -75,19 +65,5 @@ function Set-ITGlueUsers {
 
     $resource_uri = ('/users/{0}' -f $id)
 
-    $body = ConvertTo-Json -InputObject $data -Depth $ITGlue_JSON_Conversion_Depth
-
-    try {
-        $ITGlue_Headers.Add('x-api-key', (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'N/A', $ITGlue_API_Key).GetNetworkCredential().Password)
-        $rest_output = Invoke-RestMethod -method 'PATCH' -uri ($ITGlue_Base_URI + $resource_uri) -headers $ITGlue_Headers `
-            -body $body -ErrorAction Stop -ErrorVariable $web_error
-    } catch {
-        Write-Error $_
-    } finally {
-        [void] ($ITGlue_Headers.Remove('x-api-key')) # Quietly clean up scope so the API key doesn't persist
-    }
-
-    $data = @{}
-    $data = $rest_output
-    return $data
+    return Set-ITGlue -resource_uri $resource_uri -data $data
 }


### PR DESCRIPTION
Added `New-ITGlue`
Added `Get-ITGlue`
Added `Set-ITGlue`
Added `Remove-ITGlue`

All GET requests have their filter parameters moved to the `$filter_list` variable. The internal function `Get-ITGlue` handles creating the new URI.

All other requests with filters have their filter parameters moved from the `$body` variable also to the `$filter_list` variable. The internal function will still add all filters to the body (but this can easily be changed, **take special note of show_password in Passwords.ps1 if we do, the url is still handled by the external function as a result of this**) because that is how it was documented.

`$body` variable has been removed from all exposed functions and move to the internal `*-ITGlue` functions.