### PR TITLE
 Functionality to Fetch All Results with Get- Cmdlets

### DIFF
--- a/ITGlueAPI/Internal/APICalls.ps1
+++ b/ITGlueAPI/Internal/APICalls.ps1
@@ -75,7 +75,7 @@ function Invoke-ITGlueRequest {
                 $result = $api_response
             }
 
-        } while($AllResults -and $api_response.meta.'total-pages' -and $page -le ($api_response.meta.'total-pages'))
+        } while($AllResults -and $api_response.meta.'total-pages' -and $page -lt ($api_response.meta.'total-pages'))
 
         if($AllResults -and $api_response.meta) {
             $result.meta = $api_response.meta

--- a/ITGlueAPI/Resources/ConfigurationInterfaces.ps1
+++ b/ITGlueAPI/Resources/ConfigurationInterfaces.ps1
@@ -40,7 +40,11 @@ function Get-ITGlueConfigurationInterfaces {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(ParameterSetName = 'show', Mandatory = $true)]
-        [Nullable[Int64]]$id
+        [Nullable[Int64]]$id,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/configurations/{0}/relationships/configuration_interfaces/' -f $conf_id)
@@ -73,7 +77,7 @@ function Get-ITGlueConfigurationInterfaces {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGlueConfigurationInterfaces {

--- a/ITGlueAPI/Resources/ConfigurationStatuses.ps1
+++ b/ITGlueAPI/Resources/ConfigurationStatuses.ps1
@@ -27,7 +27,11 @@ function Get-ITGlueConfigurationStatuses {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/configuration_statuses/{0}' -f $id)
@@ -49,7 +53,7 @@ function Get-ITGlueConfigurationStatuses {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGlueConfigurationStatuses {

--- a/ITGlueAPI/Resources/ConfigurationTypes.ps1
+++ b/ITGlueAPI/Resources/ConfigurationTypes.ps1
@@ -27,7 +27,11 @@ function Get-ITGlueConfigurationTypes {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/configuration_types/{0}' -f $id)
@@ -49,7 +53,7 @@ function Get-ITGlueConfigurationTypes {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGlueConfigurationTypes {

--- a/ITGlueAPI/Resources/Configurations.ps1
+++ b/ITGlueAPI/Resources/Configurations.ps1
@@ -126,7 +126,14 @@ function Get-ITGlueConfigurations {
         [Parameter(ParameterSetName = 'index_psa')]
         [Parameter(ParameterSetName = 'index_rmm_psa')]
         [Parameter(ParameterSetName = 'show')]
-        [String]$include = ''
+        [String]$include = '',
+
+        [Parameter(ParameterSetName = 'index')]
+        [Parameter(ParameterSetName = 'index_rmm')]
+        [Parameter(ParameterSetName = 'index_psa')]
+        [Parameter(ParameterSetName = 'index_rmm_psa')]
+        [Parameter(ParameterSetName = 'show')]
+        [Switch]$all
     )
 
     if($organization_id) {
@@ -194,7 +201,7 @@ function Get-ITGlueConfigurations {
         $query_params['include'] = $include
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGlueConfigurations {

--- a/ITGlueAPI/Resources/ContactTypes.ps1
+++ b/ITGlueAPI/Resources/ContactTypes.ps1
@@ -27,7 +27,11 @@ function Get-ITGlueContactTypes {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/contact_types/{0}' -f $id)
@@ -49,7 +53,7 @@ function Get-ITGlueContactTypes {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGlueContactTypes {

--- a/ITGlueAPI/Resources/Contacts.ps1
+++ b/ITGlueAPI/Resources/Contacts.ps1
@@ -79,7 +79,12 @@ function Get-ITGlueContacts {
         [Parameter(ParameterSetName = 'index')]
         [Parameter(ParameterSetName = 'index_psa')]
         [Parameter(ParameterSetName = 'show')]
-        $include = ''
+        $include = '',
+
+        [Parameter(ParameterSetName = 'index')]
+        [Parameter(ParameterSetName = 'index_psa')]
+        [Parameter(ParameterSetName = 'show')]
+        [Switch]$all
     )
 
     $resource_uri = ('/contacts/{0}' -f $id)
@@ -135,7 +140,7 @@ function Get-ITGlueContacts {
         $query_params += @{'include' = $include}
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGlueContacts {

--- a/ITGlueAPI/Resources/Countries.ps1
+++ b/ITGlueAPI/Resources/Countries.ps1
@@ -19,7 +19,11 @@ function Get-ITGlueCountries {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(ParameterSetName = "show")]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/countries/{0}' -f $id)
@@ -44,5 +48,5 @@ function Get-ITGlueCountries {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -RequestURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }

--- a/ITGlueAPI/Resources/Domains.ps1
+++ b/ITGlueAPI/Resources/Domains.ps1
@@ -22,7 +22,10 @@ function Get-ITGlueDomains {
 
         [Parameter(ParameterSetName = 'index')]
         [ValidateSet('passwords', 'attachments', 'user_resource_accesses', 'group_resource_accesses')]
-        [String]$include = ''
+        [String]$include = '',
+
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = '/domains'
@@ -54,5 +57,5 @@ function Get-ITGlueDomains {
         $query_params['include'] = $include
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }

--- a/ITGlueAPI/Resources/Expirations.ps1
+++ b/ITGlueAPI/Resources/Expirations.ps1
@@ -41,7 +41,11 @@ function Get-ITGlueExpirations {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'show')]
-        [Nullable[Int64]]$id
+        [Nullable[Int64]]$id,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/expirations/{0}' -f $id)
@@ -87,5 +91,5 @@ function Get-ITGlueExpirations {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }

--- a/ITGlueAPI/Resources/FlexibleAssetFields.ps1
+++ b/ITGlueAPI/Resources/FlexibleAssetFields.ps1
@@ -46,7 +46,11 @@ function Get-ITGlueFlexibleAssetFields {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/flexible_asset_fields/{0}' -f $id)
@@ -85,7 +89,7 @@ function Get-ITGlueFlexibleAssetFields {
         $resource_uri = ('/flexible_asset_fields/{0}' -f $id)
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGlueFlexibleAssetFields {

--- a/ITGlueAPI/Resources/FlexibleAssetTypes.ps1
+++ b/ITGlueAPI/Resources/FlexibleAssetTypes.ps1
@@ -35,7 +35,11 @@ function Get-ITGlueFlexibleAssetTypes {
         [String]$include = '',
 
         [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/flexible_asset_types/{0}' -f $id)
@@ -71,7 +75,7 @@ function Get-ITGlueFlexibleAssetTypes {
         $query_params['include'] = $include
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGlueFlexibleAssetTypes {

--- a/ITGlueAPI/Resources/FlexibleAssets.ps1
+++ b/ITGlueAPI/Resources/FlexibleAssets.ps1
@@ -46,7 +46,11 @@ function Get-ITGlueFlexibleAssets {
         [String]$include = $null,
 
         [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/flexible_assets/{0}' -f $id)
@@ -78,7 +82,7 @@ function Get-ITGlueFlexibleAssets {
         $query_params['include'] = $include
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGlueFlexibleAssets {

--- a/ITGlueAPI/Resources/Groups.ps1
+++ b/ITGlueAPI/Resources/Groups.ps1
@@ -16,7 +16,11 @@ function Get-ITGlueGroups {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/groups/{0}' -f $id)
@@ -38,5 +42,5 @@ function Get-ITGlueGroups {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }

--- a/ITGlueAPI/Resources/Locations.ps1
+++ b/ITGlueAPI/Resources/Locations.ps1
@@ -67,7 +67,12 @@ function Get-ITGlueLocations {
         [Parameter(ParameterSetName = 'index')]
         [Parameter(ParameterSetName = 'index_psa')]
         [Parameter(ParameterSetName = 'show')]
-        [String]$include = ''
+        [String]$include = '',
+
+        [Parameter(ParameterSetName = 'index')]
+        [Parameter(ParameterSetName = 'index_psa')]
+        [Parameter(ParameterSetName = 'show')]
+        [Switch]$all
     )
 
     $resource_uri = ('/locations/{0}' -f $id)
@@ -115,7 +120,7 @@ function Get-ITGlueLocations {
     }
 
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGlueLocations {

--- a/ITGlueAPI/Resources/Logs.ps1
+++ b/ITGlueAPI/Resources/Logs.ps1
@@ -73,7 +73,10 @@ function Get-ITGlueLogs {
 
             [Parameter(ParameterSetName = 'index')]
             [ValidateRange ( 1, 1000 )]
-            [Nullable[int]]$page_size = $null
+            [Nullable[int]]$page_size = $null,
+
+            [Parameter(ParameterSetName = 'index')]
+            [Switch]$all
         )
 
         $resource_uri = '/logs'
@@ -92,5 +95,5 @@ function Get-ITGlueLogs {
             }
         }
 
-        return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+        return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
     }

--- a/ITGlueAPI/Resources/Manufacturers.ps1
+++ b/ITGlueAPI/Resources/Manufacturers.ps1
@@ -27,7 +27,11 @@ function Get-ITGlueManufacturers {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/manufacturers/{0}' -f $id)
@@ -49,7 +53,7 @@ function Get-ITGlueManufacturers {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGlueManufacturers {

--- a/ITGlueAPI/Resources/Models.ps1
+++ b/ITGlueAPI/Resources/Models.ps1
@@ -37,7 +37,11 @@ function Get-ITGlueModels {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/models/{0}' -f $id)
@@ -62,7 +66,7 @@ function Get-ITGlueModels {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGlueModels {

--- a/ITGlueAPI/Resources/OperatingSystems.ps1
+++ b/ITGlueAPI/Resources/OperatingSystems.ps1
@@ -16,7 +16,11 @@ function Get-ITGlueOperatingSystems {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/operating_systems/{0}' -f $id)
@@ -38,5 +42,5 @@ function Get-ITGlueOperatingSystems {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }

--- a/ITGlueAPI/Resources/OrganizationStatuses.ps1
+++ b/ITGlueAPI/Resources/OrganizationStatuses.ps1
@@ -27,7 +27,11 @@ function Get-ITGlueOrganizationStatuses {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/organization_statuses/{0}' -f $id)
@@ -49,7 +53,7 @@ function Get-ITGlueOrganizationStatuses {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGlueOrganizationStatuses {

--- a/ITGlueAPI/Resources/OrganizationTypes.ps1
+++ b/ITGlueAPI/Resources/OrganizationTypes.ps1
@@ -27,7 +27,11 @@ function Get-ITGlueOrganizationTypes {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/organization_types/{0}' -f $id)
@@ -49,7 +53,7 @@ function Get-ITGlueOrganizationTypes {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGlueOrganizationTypes {

--- a/ITGlueAPI/Resources/Organizations.ps1
+++ b/ITGlueAPI/Resources/Organizations.ps1
@@ -66,7 +66,11 @@ function Get-ITGlueOrganizations {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+        
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/organizations/{0}' -f $id)
@@ -127,7 +131,7 @@ function Get-ITGlueOrganizations {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGlueOrganizations {

--- a/ITGlueAPI/Resources/PasswordCategories.ps1
+++ b/ITGlueAPI/Resources/PasswordCategories.ps1
@@ -27,7 +27,11 @@ function Get-ITGluePasswordCategories {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/password_categories/{0}' -f $id)
@@ -49,7 +53,7 @@ function Get-ITGluePasswordCategories {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGluePasswordCategories {

--- a/ITGlueAPI/Resources/Passwords.ps1
+++ b/ITGlueAPI/Resources/Passwords.ps1
@@ -66,7 +66,11 @@ function Get-ITGluePasswords {
 
         [Parameter(ParameterSetName = 'index')]
         [Parameter(ParameterSetName = 'show')]
-        $include = ''
+        $include = '',
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/passwords/{0}' -f $id)
@@ -119,7 +123,7 @@ function Get-ITGluePasswords {
         $query_params['include'] = $include
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGluePasswords {

--- a/ITGlueAPI/Resources/Platforms.ps1
+++ b/ITGlueAPI/Resources/Platforms.ps1
@@ -16,7 +16,11 @@ function Get-ITGluePlatforms {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/platforms/{0}' -f $id)
@@ -38,5 +42,5 @@ function Get-ITGluePlatforms {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }

--- a/ITGlueAPI/Resources/Regions.ps1
+++ b/ITGlueAPI/Resources/Regions.ps1
@@ -26,7 +26,11 @@ function Get-ITGlueRegions {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/regions/{0}' -f $id)
@@ -57,5 +61,5 @@ function Get-ITGlueRegions {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }

--- a/ITGlueAPI/Resources/UserMetrics.ps1
+++ b/ITGlueAPI/Resources/UserMetrics.ps1
@@ -22,7 +22,10 @@ function Get-ITGlueUserMetrics {
         [Nullable[Int64]]$page_number = $null,
 
         [Parameter(ParameterSetName = 'index')]
-        [Nullable[int]]$page_size = $null
+        [Nullable[int]]$page_size = $null,
+
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = '/user_metrics'
@@ -53,5 +56,5 @@ function Get-ITGlueUserMetrics {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }

--- a/ITGlueAPI/Resources/Users.ps1
+++ b/ITGlueAPI/Resources/Users.ps1
@@ -23,7 +23,11 @@ function Get-ITGlueUsers {
         [Nullable[int]]$page_size = $null,
 
         [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Nullable[Int64]]$id = $null,
+
+        [Parameter(ParameterSetName = 'show')]
+        [Parameter(ParameterSetName = 'index')]
+        [Switch]$all
     )
 
     $resource_uri = ('/users/{0}' -f $id)
@@ -51,7 +55,7 @@ function Get-ITGlueUsers {
         }
     }
 
-    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params
+    return Invoke-ITGlueRequest -Method GET -ResourceURI $resource_uri -QueryParams $query_params -AllResults:$all
 }
 
 function Set-ITGlueUsers {


### PR DESCRIPTION
Addresses #61 with changes to **Invoke-ITGlueRequest**: Adds **-AllResults** switch to handle paging and multiple requests to fetch all results with one call.

Adds an **-all** switch to all applicable Get-* cmdlets. This can be used in unison with **-page_size** to limit the number of sequential requests to the API.

Ex. `Get-ITGlueOrganizations -all -page_size 1000`

I have tested all modified cmdlets for functionality and accuracy of returned data.

_This also includes an unrelated "typo" fix on Countries.ps1 to **-RequestURI**, that missed the change to **-ResourceURI** in refactor._